### PR TITLE
fix: TM-538 add new user to organisation after accept invite to monitoring project

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -94,32 +94,13 @@ class AuthController extends Controller
         $verification = VerificationModel::where('token', '=', $data['token'])
             ->where('user_id', '=', $me->id)
             ->firstOrFail();
-            $verification->delete();
+
         $me->email_address_verified_at = new DateTime('now', new DateTimeZone('UTC'));
+        $me->saveOrFail();
+        $verification->delete();
+
         return JsonResponseHelper::success((object) [], 200);
     }
-
-
-    public function acceptInvite($email): ProjectInviteResource
-    {        
-        $invite = ProjectInvite::where('email_address', $email)
-            ->first();
-
-        if (! $invite) {
-            throw new ModelNotFoundException();
-        } elseif ($invite['accepted_at'] !== null) {
-            throw new InviteAlreadyAcceptedException();
-        }
-
-        Auth::user()->projects()->sync([$invite->project_id => ['is_monitoring' => true]], false);
-
-        $invite->accepted_at = now();
-        $invite->saveOrFail();
-
-        return new ProjectInviteResource($invite);
-    }
-
-
 
     public function verifyUnauthorizedAction(VerifyRequest $request): JsonResponse
     {
@@ -130,12 +111,20 @@ class AuthController extends Controller
         $user = UserModel::where('id', $verification->user_id)->firstOrFail();
         $user->email_address_verified_at = new DateTime('now', new DateTimeZone('UTC'));
         $user->saveOrFail();
+        $verification->delete();
 
-        $invites = ProjectInvite::where('email_address', $user->email_address)->get();
+        $invites = ProjectInvite::where('email_address', $user->email_address)->orderBy('created_at', 'desc')->get();
+        $is_first = true;
         foreach ($invites as $invite) {
             $invite = ProjectInvite::where('token', $invite->token)
                 ->where('email_address', $user->email_address)
                 ->first();
+            if ($is_first) {
+                $organisation_id = $invite->project->organisation_id;
+                $user->organisation_id = $organisation_id;
+                $user->saveOrFail();
+                $is_first = false;
+            }
             $user->projects()->sync([$invite->project_id => ['is_monitoring' => true]]);
             if ($invite->accepted_at === null) {
                 $invite->accepted_at = now();

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -116,8 +116,7 @@ class AuthController extends Controller
                 ->where('email_address', $user->email_address)
                 ->first();
             if ($is_first) {
-                $organisation_id = $invite->project->organisation_id;
-                $user->organisation_id = $organisation_id;
+                $user->organisation_id = $invite->project->organisation_id;
                 $user->saveOrFail();
                 $is_first = false;
             }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\FailedLoginException;
-use App\Exceptions\InviteAlreadyAcceptedException;
 use App\Exceptions\SamePasswordException;
 use App\Helpers\JsonResponseHelper;
 use App\Http\Requests\ChangePasswordRequest;
@@ -22,13 +21,10 @@ use App\Models\V2\Projects\ProjectInvite;
 use DateTime;
 use DateTimeZone;
 use Exception;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-
-use App\Http\Resources\V2\Projects\ProjectInviteResource;
 
 class AuthController extends Controller
 {

--- a/app/Http/Controllers/V2/Projects/CreateProjectInviteController.php
+++ b/app/Http/Controllers/V2/Projects/CreateProjectInviteController.php
@@ -33,7 +33,6 @@ class CreateProjectInviteController extends Controller
         $token = $this->generateUniqueToken();
         $data['project_id'] = $project->id;
         $data['token'] = $token;
-        $organisation = Organisation::where('id', $project->organisation_id)->first();
         if ($existingUser) {
             $existingUser->projects()->sync([$project->id => ['is_monitoring' => true]], false);
             $data['accepted_at'] = now();
@@ -43,6 +42,7 @@ class CreateProjectInviteController extends Controller
             }
             Mail::to($data['email_address'])->queue(new V2ProjectMonitoringNotification($project->name, $url));
         } else {
+            $organisation = Organisation::where('id', $project->organisation_id)->first();
             $projectInvite = $project->invites()->create($data);
             Mail::to($data['email_address'])->queue(new V2ProjectInviteReceived($project->name, $organisation->name, $url));
         }


### PR DESCRIPTION
There was a missing piece of logic that now we need to add a new user into the organization of the project that invited to monitor.

Commits: 
- fix: TM-538 add missing logic for users outside TM signing up
- fix: TM-538 deleted imports
