### PR TITLE
fix: TM-527 remove organization projects on list

### DIFF
--- a/app/Http/Controllers/V2/Projects/ViewMyProjectsController.php
+++ b/app/Http/Controllers/V2/Projects/ViewMyProjectsController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers\V2\Projects;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\V2\Projects\ProjectsCollection;
-use App\Models\V2\Projects\Project;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -14,16 +12,7 @@ class ViewMyProjectsController extends Controller
     public function __invoke(Request $request): ProjectsCollection
     {
         $user = Auth::user();
-        $userProjects = $user->projects->pluck('id')->toArray();
 
-        $projects = Project::query()
-            ->where('organisation_id', $user->organisation->id)
-            ->orWhere(function (Builder $query) use ($userProjects) {
-                $query->whereIn('id', $userProjects);
-            })
-            ->distinct()
-            ->get();
-
-        return new ProjectsCollection($projects);
+        return new ProjectsCollection($user->projects);
     }
 }


### PR DESCRIPTION
Previously the endpoint that lists all the projects available for a given user, will take into consideration the organisation's projects as well.
With this PR, we are removing this behaviour as requested.