### PR TITLE
[TM-595] Use the draft state in UpdateRequests.

### DIFF
--- a/app/Http/Controllers/Traits/HandlesUpdateRequests.php
+++ b/app/Http/Controllers/Traits/HandlesUpdateRequests.php
@@ -20,7 +20,7 @@ trait HandlesUpdateRequests
 
         if (! empty($updateRequest)) {
             $updateRequest->content = array_merge($updateRequest->content, $answers);
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
+            $updateRequest->status = UpdateRequest::STATUS_DRAFT;
             $updateRequest->save();
         } else {
             $updateRequest = UpdateRequest::create([
@@ -30,7 +30,7 @@ trait HandlesUpdateRequests
                 'framework_key' => $entity->framework_key,
                 'updaterequestable_type' => get_class($entity),
                 'updaterequestable_id' => $entity->id,
-                'status' => UpdateRequest::STATUS_AWAITING_APPROVAL,
+                'status' => UpdateRequest::STATUS_DRAFT,
                 'content' => $answers,
             ]);
         }

--- a/app/Http/Controllers/V2/Nurseries/SubmitNurseryWithFormController.php
+++ b/app/Http/Controllers/V2/Nurseries/SubmitNurseryWithFormController.php
@@ -34,8 +34,8 @@ class SubmitNurseryWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $nursery->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $nursery->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/NurseryReports/SubmitNurseryReportWithFormController.php
+++ b/app/Http/Controllers/V2/NurseryReports/SubmitNurseryReportWithFormController.php
@@ -34,8 +34,8 @@ class SubmitNurseryReportWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $nurseryReport->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $nurseryReport->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/ProjectReports/SubmitProjectReportWithFormController.php
+++ b/app/Http/Controllers/V2/ProjectReports/SubmitProjectReportWithFormController.php
@@ -34,8 +34,8 @@ class SubmitProjectReportWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $projectReport->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $projectReport->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/Projects/SubmitProjectWithFormController.php
+++ b/app/Http/Controllers/V2/Projects/SubmitProjectWithFormController.php
@@ -34,8 +34,8 @@ class SubmitProjectWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $project->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $project->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/SiteReports/SubmitSiteReportWithFormController.php
+++ b/app/Http/Controllers/V2/SiteReports/SubmitSiteReportWithFormController.php
@@ -34,8 +34,8 @@ class SubmitSiteReportWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $siteReport->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $siteReport->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/Sites/SubmitSiteWithFormController.php
+++ b/app/Http/Controllers/V2/Sites/SubmitSiteWithFormController.php
@@ -35,8 +35,8 @@ class SubmitSiteWithFormController extends Controller
             ->first();
 
         if (! empty($updateRequest)) {
-            $updateRequest->status = UpdateRequest::STATUS_AWAITING_APPROVAL;
-            $site->save();
+            $updateRequest->update([ 'status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
+            $site->update([ 'update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL ]);
 
             Action::where('targetable_type', UpdateRequest::class)
                 ->where('targetable_id', $updateRequest->id)


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-595

FE PR: https://github.com/wri/wri-terramatch-website/pull/63

UpdateRequests weren't using the "draft" status that was defined on the model. The main implication of this is that when an update request was created or edited, it was automatically put into "awaiting approval", which meant it couldn't be edited further, and the "save and continue later" flow wasn't non-functional.