### PR TITLE
[TM-415] Include unsubmitted tasks in the total_reporting_tasks attribute

### DIFF
--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -462,8 +462,9 @@ class Project extends Model implements HasMedia, AuditableContract, ApprovalFlow
             $projectReportPending = $this->getReportPendingCount(ProjectReport::class, $dueDate, "project_id", $siteIds, $nurseryIds);
             $siteRepPending = $this->getReportPendingCount(SiteReport::class, $dueDate, "site_id", $siteIds, $nurseryIds);
             $nurRepPending = $this->getReportPendingCount(NurseryReport::class, $dueDate, "nursery_id", $siteIds, $nurseryIds);
+            $hasPendingTask = Task::forProjectAndDate($this, $dueDate)->whereNot('status', Task::STATUS_COMPLETE)->exists();
 
-            if ($projectReportPending + $siteRepPending + $nurRepPending > 0) {
+            if ($projectReportPending + $siteRepPending + $nurRepPending > 0 || $hasPendingTask) {
                 $pendingReportingTasks++;
             }
         }


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-415

This turned out to be a very simple additional to what had already been done on this ticket. However, there is a great simplification that will take place as part of TM-560, once `Task` has a more robust `status` field, we'll be able to simply count the number of `tasks` in `due` or `needs-more-information` to calculate this, which will be much faster.