### PR TITLE
[TM-560] Task status states

### DIFF
--- a/app/Console/Commands/MigrateTaskStatuses.php
+++ b/app/Console/Commands/MigrateTaskStatuses.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Exceptions\InvalidStatusException;
+use App\Models\V2\Tasks\Task;
+use App\StateMachines\ReportStatusStateMachine;
+use App\StateMachines\TaskStatusStateMachine;
+use Illuminate\Console\Command;
+
+class MigrateTaskStatuses extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:migrate-task-statuses';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates all Tasks in database to match current status state machine values';
+
+    private const VALID_STATUSES = [
+        TaskStatusStateMachine::DUE,
+        TaskStatusStateMachine::AWAITING_APPROVAL,
+        TaskStatusStateMachine::NEEDS_MORE_INFORMATION,
+        TaskStatusStateMachine::APPROVED,
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $numClean = 0;
+        $numErrors = 0;
+        // Since we want to operate on trashed models too and we need to do a direct DB update (because the current
+        // statuses aren't part of the updated state machine), we're re-implementing most of the logic in
+        // Task->checkStatus
+        Task::withoutTimestamps(function () use (&$numErrors, &$numClean) {
+            Task::withTrashed()->whereNotIn('status',self::VALID_STATUSES)->chunkbyId(
+                100,
+                function ($tasks) use (&$numErrors, &$numClean) {
+                    foreach ($tasks as $task) {
+                        try {
+                            // Fake the status into 'awaiting-approval' so that checkStatus()'s transitions are all
+                            // legal.
+                            $task->status = TaskStatusStateMachine::AWAITING_APPROVAL;
+                            $task->checkStatus();
+                            if ($task->status == TaskStatusStateMachine::AWAITING_APPROVAL) {
+                                // if we "transitioned" to awaiting approval, the task won't have been saved because
+                                // that's what we faked into above
+                                $task->save();
+                            }
+
+                            $numClean++;
+                        } catch (InvalidStatusException $exception) {
+                            if ($this->processException($task, $exception)) {
+                                $numClean++;
+                            } else {
+                                $numErrors++;
+                            }
+                        }
+                    }
+                });
+        });
+
+        echo "Migration completed. [Tasks with errors: $numErrors, successful transitions: $numClean]";
+    }
+
+    private function processException(Task $task, InvalidStatusException $exception): bool
+    {
+        if (!$task->projectReport()->exists() && !$task->siteReports()->exists() && !$task->nurseryReports()->exists()) {
+            echo "Task $task->id was due on $task->due_at and has no associated reports. Moving to 'approved'.\n";
+            $task->status = TaskStatusStateMachine::APPROVED;
+            $task->save();
+            return true;
+        }
+
+        $reportRelations = [$task->projectReport(), $task->siteReports(), $task->nurseryReports()];
+        $reportStatuses = array_unique(array_merge(...array_map(function ($relation) {
+            return $relation->distinct()->pluck('status')->all();
+        }, $reportRelations)));
+        if (in_array(ReportStatusStateMachine::DUE, $reportStatuses) ||
+            in_array(ReportStatusStateMachine::STARTED, $reportStatuses)) {
+            echo "Task $task->id was due on $task->due_at and has reports in 'due' or 'started'. Moving to 'due'.\n";
+            $task->status = TaskStatusStateMachine::DUE;
+            $task->save();
+            return true;
+        }
+
+        $message = $exception->getMessage();
+        echo "Task $task->id: $message\n";
+        return false;
+    }
+}

--- a/app/Console/Commands/Migration/CreateDueReportsMigrationCommand.php
+++ b/app/Console/Commands/Migration/CreateDueReportsMigrationCommand.php
@@ -19,6 +19,7 @@ use App\Models\V2\Sites\SiteReport;
 use App\Models\V2\Tasks\Task;
 use App\Models\V2\UpdateRequests\UpdateRequest;
 use App\StateMachines\ReportStatusStateMachine;
+use App\StateMachines\TaskStatusStateMachine;
 use Illuminate\Console\Command;
 
 class CreateDueReportsMigrationCommand extends Command
@@ -196,7 +197,7 @@ class CreateDueReportsMigrationCommand extends Command
                 'period_key' => $stub->due_at->year . '-' . ($stub->due_at->month < 10 ? '0'. $stub->due_at->month : $stub->due_at->month),
             ],
             [
-                'status' => Task::STATUS_DUE,
+                'status' => TaskStatusStateMachine::DUE,
                 'due_at' => $stub->due_at,
             ]
         );

--- a/app/Console/Commands/Migration/CreateTasksMigrationCommand.php
+++ b/app/Console/Commands/Migration/CreateTasksMigrationCommand.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands\Migration;
 use App\Models\V2\Projects\Project;
 use App\Models\V2\Projects\ProjectReport;
 use App\Models\V2\Tasks\Task;
+use App\StateMachines\TaskStatusStateMachine;
 use Illuminate\Console\Command;
 
 class CreateTasksMigrationCommand extends Command
@@ -51,7 +52,7 @@ class CreateTasksMigrationCommand extends Command
                 $map = [
                         'organisation_id' => $project->organisation_id,
                         'project_id' => $project->id,
-                        'status' => Task::STATUS_COMPLETE,
+                        'status' => $report->status,
                         'period_key' => $item['year'] . '-' . ($item['month'] < 10 ? '0'. $item['month'] : $item['month']),
                         'due_at' => $report->due_at,
                 ];
@@ -75,7 +76,7 @@ class CreateTasksMigrationCommand extends Command
                 $map = [
                         'organisation_id' => $project->organisation_id,
                         'project_id' => $project->id,
-                        'status' => Task::STATUS_COMPLETE,
+                        'status' => $report->status,
                         'period_key' => $item['year'] . '-' . ($item['month'] < 10 ? '0' . $item['month'] : $item['month']),
                         'due_at' => $report->created_at,
                 ];

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -342,6 +342,8 @@ class Handler extends ExceptionHandler
                 return JsonResponseHelper::error($errors, 422);
             case ProgrammeHasNoAimsException::class:
                 return JsonResponseHelper::error([], 404);
+            case InvalidStatusException::class:
+                return JsonResponseHelper::error($exception->getMessage(), 422);
             default:
                 if (config('app.env') == 'local') {
                     return new Response($this->renderExceptionContent($exception), 500, ['Content-Type' => 'text/html']);

--- a/app/Exceptions/InvalidStatusException.php
+++ b/app/Exceptions/InvalidStatusException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class InvalidStatusException extends Exception
+{
+}

--- a/app/Http/Controllers/V2/Projects/ViewProjectTasksController.php
+++ b/app/Http/Controllers/V2/Projects/ViewProjectTasksController.php
@@ -16,22 +16,20 @@ class ViewProjectTasksController extends Controller
         $this->authorize('read', $project);
         $perPage = $request->query('per_page') ?? config('app.pagination_default', 15);
 
-
         $sortableColumns = [
             'status', '-status',
             'period_key', '-period_key',
         ];
 
-        $qry = QueryBuilder::for(Task::class)
-            ->with(['project'])
-            ->where('status', '!=', Task::STATUS_COMPLETE)
+        $query = Task::with(['project'])
+            ->isIncomplete()
             ->where('project_id', $project->id);
 
         if (in_array($request->query('sort'), $sortableColumns)) {
-            $qry->allowedSorts($sortableColumns);
+            $query->allowedSorts($sortableColumns);
         }
 
-        $collection = $qry->paginate($perPage);
+        $collection = $query->paginate($perPage);
 
         return new TasksCollection($collection);
     }

--- a/app/Http/Controllers/V2/Reports/SubmitReportWithFormController.php
+++ b/app/Http/Controllers/V2/Reports/SubmitReportWithFormController.php
@@ -32,6 +32,7 @@ class SubmitReportWithFormController extends Controller
         if (!empty($updateRequest)) {
             $updateRequest->update(['status' => UpdateRequest::STATUS_AWAITING_APPROVAL]);
             $report->update(['update_request_status' => UpdateRequest::STATUS_AWAITING_APPROVAL]);
+            $report->task->checkStatus();
 
             Action::where('targetable_type', get_class($report))
                 ->where('targetable_id', $updateRequest->id)

--- a/app/Http/Controllers/V2/Tasks/SubmitProjectTasksController.php
+++ b/app/Http/Controllers/V2/Tasks/SubmitProjectTasksController.php
@@ -2,39 +2,21 @@
 
 namespace App\Http\Controllers\V2\Tasks;
 
+use App\Exceptions\InvalidStatusException;
 use App\Http\Controllers\Controller;
-use App\Models\V2\Nurseries\NurseryReport;
-use App\Models\V2\Projects\Project;
-use App\Models\V2\Projects\ProjectReport;
-use App\Models\V2\ReportModel;
-use App\Models\V2\Sites\SiteReport;
 use App\Models\V2\Tasks\Task;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class SubmitProjectTasksController extends Controller
 {
+    /**
+     * @throws InvalidStatusException
+     */
     public function __invoke(Request $request, Task $task): JsonResponse
     {
-        $project = $task->project;
-        $this->authorize('read', $project);
-
-        $task->projectReport->awaitingApproval();
-        $this->updateReports($task->siteReports);
-        $this->updateReports($task->nurseryReports);
-
-        $task->update(['status' => Task::STATUS_COMPLETE]);
-
+        $this->authorize('update', $task);
+        $task->submitForApproval();
         return new JsonResponse('Reports successfully submitted', 200);
-    }
-
-    private function updateReports(iterable $reports) {
-        foreach ($reports as $report) {
-            if ($report->completion == 0) {
-                $report->nothingToReport();
-            } else {
-                $report->awaitingApproval();
-            }
-        }
     }
 }

--- a/app/Jobs/V2/CreateTaskDueJob.php
+++ b/app/Jobs/V2/CreateTaskDueJob.php
@@ -7,6 +7,7 @@ use App\Models\V2\Projects\Project;
 use App\Models\V2\Projects\ProjectReport;
 use App\Models\V2\Tasks\Task;
 use App\StateMachines\ReportStatusStateMachine;
+use App\StateMachines\TaskStatusStateMachine;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -45,7 +46,7 @@ class CreateTaskDueJob implements ShouldQueue
                     $task = Task::create([
                         'organisation_id' => $project->organisation_id,
                         'project_id' => $project->id,
-                        'status' => Task::STATUS_DUE,
+                        'status' => TaskStatusStateMachine::DUE,
                         'period_key' => $this->dueDate->year . '-' . $this->dueDate->month,
                         'due_at' => $this->dueDate,
                     ]);

--- a/app/Models/Traits/HasReportStatus.php
+++ b/app/Models/Traits/HasReportStatus.php
@@ -67,6 +67,24 @@ trait HasReportStatus {
         return in_array($this->status, [ReportStatusStateMachine::DUE, ReportStatusStateMachine::STARTED]);
     }
 
+    public function isCompletable(): bool
+    {
+        if ($this->isComplete()) {
+            return true;
+        }
+
+        if ($this->status == ReportStatusStateMachine::DUE && !$this->supportsNothingToReport()) {
+            return false;
+        }
+
+        return $this->status()->canBe(ReportStatusStateMachine::AWAITING_APPROVAL);
+    }
+
+    public function isComplete(): bool
+    {
+        return in_array($this->status, self::COMPLETE_STATUSES);
+    }
+
     public function getForm(): ?Form
     {
         if (is_null($this->form)) {

--- a/app/Models/V2/ReportModel.php
+++ b/app/Models/V2/ReportModel.php
@@ -2,11 +2,13 @@
 
 namespace App\Models\V2;
 
+use App\Models\V2\Tasks\Task;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
  * @property string framework_key
  * @property int id
+ * @property Task task
  */
 interface ReportModel
 {

--- a/app/Models/V2/Tasks/Task.php
+++ b/app/Models/V2/Tasks/Task.php
@@ -167,8 +167,8 @@ class Task extends Model
                 ->whereIn(
                     'status',
                     [ReportStatusStateMachine::NEEDS_MORE_INFORMATION, ReportStatusStateMachine::AWAITING_APPROVAL])
-                ->get('id', 'status')
-                ->all();
+                ->select('id', 'status')
+                ->get();
         })->flatten();
 
         if ($reportStubs->isEmpty()) {

--- a/app/Models/V2/Tasks/Task.php
+++ b/app/Models/V2/Tasks/Task.php
@@ -117,7 +117,7 @@ class Task extends Model
             throw new InvalidStatusException('Task is not submittable due to incomplete reports');
         }
 
-        // Then, ensure all reports are in a complete state. This is broken into two loops to avoid partially
+        // Then, ensure all reports are in a complete state. This is done after checking all reports to avoid
         // submitting an unsubmitable report.
         foreach ($reports as $report) {
             if ($report->isComplete()) {

--- a/app/Models/V2/Tasks/Task.php
+++ b/app/Models/V2/Tasks/Task.php
@@ -166,7 +166,8 @@ class Task extends Model
                 ->whereIn(
                     'status',
                     [ReportStatusStateMachine::NEEDS_MORE_INFORMATION, ReportStatusStateMachine::AWAITING_APPROVAL])
-                ->get('id', 'status');
+                ->get('id', 'status')
+                ->all();
         }, $reportRelations));
 
         if (count($reportStubs) == 0) {

--- a/app/Policies/V2/Tasks/TaskPolicy.php
+++ b/app/Policies/V2/Tasks/TaskPolicy.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Policies\V2\Tasks;
+
+use App\Models\User;
+use App\Models\V2\Forms\Form;
+use App\Models\V2\Tasks\Task;
+use App\Policies\Policy;
+
+class TaskPolicy extends Policy
+{
+    public function read(?User $user, ?Task $task = null): bool
+    {
+        if ($user->can('framework-' . $task->project->framework_key)) {
+            return true;
+        }
+
+        if ($user->can('manage-own') && $this->isTheirs($user, $task)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function readAll(?User $user, ?Task $task = null): bool
+    {
+        return $user->hasAnyPermission(['framework-terrafund', 'framework-ppc']);
+    }
+
+    public function update(?User $user, ?Task $task = null): bool
+    {
+        if ($user->can('framework-' . $task->project->framework_key)) {
+            return true;
+        }
+
+        return $user->can('manage-own') && $this->isTheirs($user, $task);
+    }
+
+    public function submit(?User $user, ?Task $task = null): bool
+    {
+        return $user->can('manage-own') && $this->isTheirs($user, $task);
+    }
+
+    public function delete(?User $user, ?Task $task = null): bool
+    {
+        return $user->can('framework-' . $task->project->framework_key);
+    }
+
+    public function uploadFiles(?User $user, ?Task $task = null): bool
+    {
+        return $this->isUser($user) || $this->isAdmin($user);
+    }
+
+    public function approve(?User $user, ?Task $task = null): bool
+    {
+        return $user->can('framework-' .  $task->project->framework_key);
+    }
+
+    public function updateFileProperties(?User $user, ?Task $task = null): bool
+    {
+        if ($user->can('framework-' . $task->project->framework_key)) {
+            return true;
+        }
+
+        return $user->can('manage-own') && $this->isTheirs($user, $task);
+    }
+
+    public function deleteFiles(?User $user, ?Task $task = null): bool
+    {
+        if ($user->can('framework-' . $task->project->framework_key)) {
+            return true;
+        }
+
+        return $user->can('manage-own') && $this->isTheirs($user, $task);
+    }
+
+    protected function isTheirs(?User $user, ?Task $task = null): bool
+    {
+        return $user->organisation->id == $task->project->organisation_id || $user->projects->contains($task->project->id);
+    }
+
+    public function export(?User $user, ?Form $form = null, ?Task $task = null): bool
+    {
+        return $user->can('framework-' .  $form->framework_key) or
+            $user->can('manage-own') && ($user->organisation->id == $task->organisation_id || $user->projects->contains($task->project_id));
+    }
+}

--- a/app/StateMachines/ReportStatusStateMachine.php
+++ b/app/StateMachines/ReportStatusStateMachine.php
@@ -46,4 +46,14 @@ class ReportStatusStateMachine extends StateMachine
 
         return parent::validatorForTransition($from, $to, $model);
     }
+
+    public function afterTransitionHooks(): array
+    {
+        $updateTaskStatus = fn ($fromStatus, $model) => $model->task->checkStatus();
+        return [
+            self::NEEDS_MORE_INFORMATION => [$updateTaskStatus],
+            self::AWAITING_APPROVAL => [$updateTaskStatus],
+            self::APPROVED => [$updateTaskStatus],
+        ];
+    }
 }

--- a/app/StateMachines/TaskStatusStateMachine.php
+++ b/app/StateMachines/TaskStatusStateMachine.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\StateMachines;
+
+use Asantibanez\LaravelEloquentStateMachines\StateMachines\StateMachine;
+
+class TaskStatusStateMachine extends StateMachine
+{
+    public const DUE = 'due';
+    public const AWAITING_APPROVAL = 'awaiting-approval';
+    public const NEEDS_MORE_INFORMATION = 'needs-more-information';
+    public const APPROVED = 'approved';
+
+    public function recordHistory(): bool
+    {
+        return true;
+    }
+
+    public function transitions(): array
+    {
+        return [
+            self::DUE => [self::AWAITING_APPROVAL],
+            self::AWAITING_APPROVAL => [self::NEEDS_MORE_INFORMATION, self::APPROVED],
+            self::NEEDS_MORE_INFORMATION => [self::AWAITING_APPROVAL],
+        ];
+    }
+
+    public function defaultState(): ?string
+    {
+        return self::DUE;
+    }
+}


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-560

Note: this will merge into the epic. I'm simply basing the PR on the TM-561 feature branch to present a clean diff, as that one hasn't been approved and merged yet.

This body of work accomplishes two main things:
* Implements a state machine on Task's status column, similar to that on the reports in order to add some guardrails around valid transitions.
* Hooks into state machine transitions on the Report status to check if a task should automatically transition to a new status when a child report updates. This implements a lot of the required connections for this epic on the [Miro board](https://miro.com/app/board/uXjVNvvGBro=/)