### PR TITLE
[TM-684] Remove the automatic shift back to `awaiting-approval` for t…

### DIFF
--- a/app/StateMachines/EntityStatusStateMachine.php
+++ b/app/StateMachines/EntityStatusStateMachine.php
@@ -22,7 +22,6 @@ class EntityStatusStateMachine extends StateMachine
             self::STARTED => [self::AWAITING_APPROVAL],
             self::AWAITING_APPROVAL => [self::APPROVED, self::NEEDS_MORE_INFORMATION],
             self::NEEDS_MORE_INFORMATION => [self::APPROVED],
-            self::APPROVED => [self::AWAITING_APPROVAL],
         ];
     }
 

--- a/app/StateMachines/UpdateRequestStatusStateMachine.php
+++ b/app/StateMachines/UpdateRequestStatusStateMachine.php
@@ -44,15 +44,9 @@ class UpdateRequestStatusStateMachine extends StateMachine
 
             if ($updateRequest->status == self::APPROVED) {
                 $model->approve();
-            } elseif (
-                ($updateRequest->status == self::AWAITING_APPROVAL ||
-                $updateRequest->status == self::NEEDS_MORE_INFORMATION) &&
-                $model->status == EntityStatusStateMachine::APPROVED
-            ) {
-                $model->submitForApproval();
             } elseif ($model instanceof ReportModel) {
-                // If the blocks above didn't trigger a check status on the task, we want to make sure it happens
-                // here.
+                // Changing the model status caused a task status check in the block above. Here we have a catch-all
+                // to make sure that if this update request is attached to a report model that a task check happens.
                 $model->task->checkStatus();
             }
         };


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-684

Not strictly related to the retaining the needs more information banner, this change came about due to testing of earlier work while working on TM-684. A small change: removing the transition back to `awaiting-approval` for the base entity when an update request becomes active. The original report as written is still approved, so we want to keep it that way.