### PR TITLE
[TM-427] Fix the calculation of percent complete on a linked field entity

### DIFF
--- a/app/Console/Commands/OneOff/FixReportCompletion.php
+++ b/app/Console/Commands/OneOff/FixReportCompletion.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneOff;
 
 use App\Models\V2\Nurseries\NurseryReport;
 use App\Models\V2\Projects\ProjectReport;
@@ -16,7 +16,7 @@ class FixReportCompletion extends Command
      *
      * @var string
      */
-    protected $signature = 'app:fix-report-completion';
+    protected $signature = 'one-off:fix-report-completion';
 
     /**
      * The console command description.

--- a/app/Console/Commands/OneOff/MigrateTaskStatuses.php
+++ b/app/Console/Commands/OneOff/MigrateTaskStatuses.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneOff;
 
 use App\Exceptions\InvalidStatusException;
 use App\Models\V2\Tasks\Task;
@@ -15,7 +15,7 @@ class MigrateTaskStatuses extends Command
      *
      * @var string
      */
-    protected $signature = 'app:migrate-task-statuses';
+    protected $signature = 'one-off:migrate-task-statuses';
 
     /**
      * The console command description.

--- a/app/Console/Commands/OneOff/MigrateUpdateRequestStatuses.php
+++ b/app/Console/Commands/OneOff/MigrateUpdateRequestStatuses.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\OneOff;
 
 use App\Models\V2\UpdateRequests\UpdateRequest;
 use App\StateMachines\UpdateRequestStatusStateMachine;
@@ -13,7 +13,7 @@ class MigrateUpdateRequestStatuses extends Command
      *
      * @var string
      */
-    protected $signature = 'app:migrate-update-request-statuses';
+    protected $signature = 'one-off:migrate-update-request-statuses';
 
     /**
      * The console command description.

--- a/app/Models/Traits/UsesLinkedFields.php
+++ b/app/Models/Traits/UsesLinkedFields.php
@@ -61,19 +61,45 @@ trait UsesLinkedFields
     {
         $questionCount = 0;
         $answeredCount = 0;
+        $answers = [];
 
         foreach ($form->sections as $section) {
             foreach ($section->questions as $question) {
+                $required = data_get($question, 'validation.required', true);
+                $conditionalOn = data_get($question, 'show_on_parent_condition')
+                    ? data_get($question, 'parent_id')
+                    : null;
+                $value = null;
+
                 $linkedFieldInfo = $question->getLinkedFieldInfo(['model_uuid' => $this->uuid]);
-                if (! empty($linkedFieldInfo)) {
-                    $answers[$question->uuid] = $this->getEntityLinkedFieldValue($linkedFieldInfo);
+                if (!empty($linkedFieldInfo)) {
+                    $value = $this->getEntityLinkedFieldValue($linkedFieldInfo);
+                } else {
+                    $value = data_get($this->answers, $question->uuid);
                 }
+
+                $answers[$question->uuid] = [
+                    'required' => $required,
+                    'conditionalOn' => $conditionalOn,
+                    'value' => $value,
+                ];
             }
         }
 
         foreach ($answers as $answer) {
+            if (!$answer['required']) {
+                // don't count it if the question wasn't required
+                continue;
+            }
+
+            if (!empty($answer['conditionalOn']) &&
+                !$answers[$answer['conditionalOn']]['value']) {
+                // don't count it if the question wasn't shown to the user because the parent conditional is false.
+                continue;
+            }
+
             $questionCount++;
-            if (! empty($answer)) {
+            if (!is_null($answer['value'])) {
                 $answeredCount++;
             }
         }

--- a/app/Models/Traits/UsesLinkedFields.php
+++ b/app/Models/Traits/UsesLinkedFields.php
@@ -104,7 +104,7 @@ trait UsesLinkedFields
             }
         }
 
-        return round(($answeredCount / $questionCount) * 100);
+        return $questionCount == 0 ? 100 : round(($answeredCount / $questionCount) * 100);
     }
 
     public function getAllAnswers(array $params = []): array


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-427

Fixes several problems with the calculation of % complete on a report:
* `empty()` was used on boolean fields, but `false` is a valid answer, so switched to `is_null`
* Questions that store in the `answers` JSON field on the record were skipped entirely because it only considered linked field questions
* Questions that aren't even shown to the user were considered unanswered because the `show_on_parent_condition` value on the question wasn't considered
* Questions that aren't required were counted as a ding against the completed count.

The above meant that the % complete value could be wildly off, either too high or too low depending on the nature of the form.