### PR TITLE
[TM-740] Fix up the calculation of the trees planted for a project.

### DIFF
--- a/app/Http/Controllers/V2/NurseryReports/NurseryReportsViaNurseryController.php
+++ b/app/Http/Controllers/V2/NurseryReports/NurseryReportsViaNurseryController.php
@@ -33,7 +33,7 @@ class NurseryReportsViaNurseryController extends Controller
                 AllowedFilter::exact('framework_key'),
             ])
             ->where('nursery_id', $nursery->id)
-            ->isComplete();
+            ->hasBeenSubmitted();
 
         if (in_array($request->query('sort'), $sortableColumns)) {
             $qry->allowedSorts($sortableColumns);

--- a/app/Http/Controllers/V2/ProjectReports/ProjectReportsViaProjectController.php
+++ b/app/Http/Controllers/V2/ProjectReports/ProjectReportsViaProjectController.php
@@ -35,7 +35,7 @@ class ProjectReportsViaProjectController extends Controller
                 AllowedFilter::exact('update_request_status'),
             ])
             ->where('project_id', $project->id)
-            ->isComplete();
+            ->hasBeenSubmitted();
 
         if (in_array($request->query('sort'), $sortableColumns)) {
             $qry->allowedSorts($sortableColumns);

--- a/app/Http/Controllers/V2/SiteReports/SiteReportsViaSiteController.php
+++ b/app/Http/Controllers/V2/SiteReports/SiteReportsViaSiteController.php
@@ -33,7 +33,7 @@ class SiteReportsViaSiteController extends Controller
                 AllowedFilter::exact('framework_key'),
             ])
             ->where('site_id', $site->id)
-            ->isComplete();
+            ->hasBeenSubmitted();
 
         if (in_array($request->query('sort'), $sortableColumns)) {
             $qry->allowedSorts($sortableColumns);

--- a/app/Models/Traits/HasReportStatus.php
+++ b/app/Models/Traits/HasReportStatus.php
@@ -40,6 +40,11 @@ trait HasReportStatus {
         ReportStatusStateMachine::APPROVED => 'Approved',
     ];
 
+    public const UNSUBMITTED_STATUSES = [
+        ReportStatusStateMachine::DUE,
+        ReportStatusStateMachine::STARTED,
+    ];
+
     public const COMPLETE_STATUSES = [
         ReportStatusStateMachine::AWAITING_APPROVAL,
         ReportStatusStateMachine::APPROVED,
@@ -58,6 +63,11 @@ trait HasReportStatus {
     public function scopeIsComplete(Builder $query): Builder
     {
         return $query->whereIn('status', self::COMPLETE_STATUSES);
+    }
+
+    public function scopeHasBeenSubmitted(Builder $query): Builder
+    {
+        return $query->whereNotIn('status', self::UNSUBMITTED_STATUSES);
     }
 
     public function isEditable(): bool

--- a/app/Models/V2/Projects/ProjectReport.php
+++ b/app/Models/V2/Projects/ProjectReport.php
@@ -387,14 +387,14 @@ class ProjectReport extends Model implements HasMedia, AuditableContract, Report
 
             $sitePaid = SiteReport::whereIn('id', $siteIds)
                 ->where('due_at', '<', now())
-                ->isComplete()
+                ->hasBeenSubmitted()
                 ->whereMonth('due_at', $month)
                 ->whereYear('due_at', $year)
                 ->sum('workdays_paid');
 
             $siteVolunteer = SiteReport::whereIn('id', $siteIds)
                 ->where('due_at', '<', now())
-                ->isComplete()
+                ->hasBeenSubmitted()
                 ->whereMonth('due_at', $month)
                 ->whereYear('due_at', $year)
                 ->sum('workdays_volunteer');


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-740

There were a couple of problems:
* The number was wrong because the status refactor incorrectly removed `needs-more-information` reports from the calculation.
* The SQL was pretty inefficient. This could still be better with a subselect, but wiring that up in Laravel is tricky, and this at least gets the attribute calculation down to two queries.