### PR TITLE
[TM-724] Fix aggregation of workday totals at the site and project level

### DIFF
--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -32,6 +32,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -332,22 +333,15 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
 
     public function getWorkdayCountAttribute(): int
     {
-        $paid = $this->reports()->isApproved()->sum('workdays_paid');
-        $volunteer = $this->reports()->isApproved()->sum('workdays_volunteer');
-
-        $siteIds = $this->sites()->pluck('id')->toArray();
-
-        $sitePaid = SiteReport::whereIn('id', $siteIds)
-            ->where('due_at', '<', now())
-            ->hasBeenSubmitted()
-            ->sum('workdays_paid');
-
-        $siteVolunteer = SiteReport::whereIn('id', $siteIds)
-            ->where('due_at', '<', now())
-            ->hasBeenSubmitted()
-            ->sum('workdays_volunteer');
-
-        return $paid + $volunteer + $sitePaid + $siteVolunteer;
+        $sumQueries = [
+            DB::raw("sum(`workdays_paid`) as paid"),
+            DB::raw("sum(`workdays_volunteer`) as volunteer"),
+        ];
+        $projectTotals = $this->reports()->hasBeenSubmitted()->get($sumQueries)->first();
+        // The groupBy is superfluous, but required because Laravel adds "v2_sites.project_id as laravel_through_key" to
+        // the SQL select.
+        $siteTotals = $this->submittedSiteReports()->groupBy('v2_sites.project_id')->get($sumQueries)->first();
+        return $projectTotals->paid + $projectTotals->volunteer + $siteTotals->paid + $siteTotals->volunteer;
     }
 
     public function getTotalJobsCreatedAttribute(): int
@@ -437,6 +431,18 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
     }
 
     /**
+     * @return HasManyThrough A relation for all site reports associated with this project that is for an approved
+     *   site, and has a report status past due/started (has been submitted).
+     */
+    private function submittedSiteReports(): HasManyThrough
+    {
+        return $this
+            ->siteReports()
+            ->where('v2_sites.status', EntityStatusStateMachine::APPROVED)
+            ->whereNotIn('v2_site_reports.status', SiteReport::UNSUBMITTED_STATUSES);
+    }
+
+    /**
      * @return array The array of site report IDs for all reports associated with sites that have been approved, and
      *   have a report status not in due or started (reports that have been submitted).
      */
@@ -444,11 +450,6 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
     {
         // scopes that use status don't work on the HasManyThrough because both Site and SiteReport have
         // a status field.
-        return $this
-            ->siteReports()
-            ->where('v2_sites.status', EntityStatusStateMachine::APPROVED)
-            ->whereNotIn('v2_site_reports.status', SiteReport::UNSUBMITTED_STATUSES)
-            ->pluck('v2_site_reports.id')
-            ->toArray();
+        return $this->submittedSiteReports()->pluck('v2_site_reports.id')->toArray();
     }
 }

--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -341,7 +341,7 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
         // The groupBy is superfluous, but required because Laravel adds "v2_sites.project_id as laravel_through_key" to
         // the SQL select.
         $siteTotals = $this->submittedSiteReports()->groupBy('v2_sites.project_id')->get($sumQueries)->first();
-        return $projectTotals->paid + $projectTotals->volunteer + $siteTotals->paid + $siteTotals->volunteer;
+        return $projectTotals?->paid + $projectTotals?->volunteer + $siteTotals?->paid + $siteTotals?->volunteer;
     }
 
     public function getTotalJobsCreatedAttribute(): int

--- a/app/Models/V2/Sites/Site.php
+++ b/app/Models/V2/Sites/Site.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -291,10 +292,12 @@ class Site extends Model implements HasMedia, AuditableContract, EntityModel
 
     public function getWorkdayCountAttribute(): int
     {
-        $volunteers = $this->reports()->sum('workdays_volunteer');
-        $paid = $this->reports()->sum('workdays_paid');
+        $totals = $this->reports()->hasBeenSubmitted()->get([
+            DB::raw("sum(`workdays_volunteer`) as volunteer"),
+            DB::raw("sum(`workdays_paid`) as paid"),
+        ])->first();
 
-        return $volunteers + $paid;
+        return $totals->volunteer + $totals->paid;
     }
 
     public function getFrameworkUuidAttribute(): ?string

--- a/app/Models/V2/Sites/Site.php
+++ b/app/Models/V2/Sites/Site.php
@@ -297,7 +297,7 @@ class Site extends Model implements HasMedia, AuditableContract, EntityModel
             DB::raw("sum(`workdays_paid`) as paid"),
         ])->first();
 
-        return $totals->volunteer + $totals->paid;
+        return $totals?->paid + $totals?->volunteer;
     }
 
     public function getFrameworkUuidAttribute(): ?string


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-724

This had two problems:
 * Similar to TM-740, it was skipping reports in needs-more-information state (a mistake in the status refactor)
 * At the project level, it was fetching site reports using site ids, so the reports it was aggregating from were completely wrong.

I also improved the performance of this attribute calculation, similar to the work for 724.