### PR TITLE
[TM-702] Emails when entities and update requests move into approved or needs-more-information.

### DIFF
--- a/app/Jobs/V2/SendEntityStatusChangeEmailsJob.php
+++ b/app/Jobs/V2/SendEntityStatusChangeEmailsJob.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs\V2;
+
+use App\Mail\EntityStatusChange as EntityStatusChangeMail;
+use App\Models\V2\EntityModel;
+use App\StateMachines\EntityStatusStateMachine;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class SendEntityStatusChangeEmailsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    private EntityModel $entity;
+
+    public function __construct(EntityModel $entity)
+    {
+        $this->entity = $entity;
+    }
+
+    public function handle(): void
+    {
+        if ($this->entity->status != EntityStatusStateMachine::APPROVED &&
+            $this->entity->status != EntityStatusStateMachine::NEEDS_MORE_INFORMATION &&
+            $this->entity->update_request_status != EntityStatusStateMachine::NEEDS_MORE_INFORMATION) {
+            return;
+        }
+
+        $emailAddresses = $this->entity->project->users()->pluck('email_address');
+        if (empty($emailAddresses)) {
+            return;
+        }
+
+        foreach ($emailAddresses as $emailAddress) {
+            Mail::to($emailAddress)->send(new EntityStatusChangeMail($this->entity));
+        }
+    }
+}

--- a/app/Mail/EntityStatusChange.php
+++ b/app/Mail/EntityStatusChange.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\V2\EntityModel;
+use App\Models\V2\ReportModel;
+use App\StateMachines\EntityStatusStateMachine;
+use Illuminate\Support\Collection;
+
+class EntityStatusChange extends Mail
+{
+    private EntityModel $entity;
+
+    public function __construct(EntityModel $entity)
+    {
+        $this->entity = $entity;
+
+        $this->subject = $this->getSubject();
+        $this->title = $this->subject;
+        $this->body = $this->getBodyParagraphs()->join('<br><br>');
+        $this->link = $this->entity->getViewLinkPath();
+        $this->cta = 'View ' . $this->getEntityName();
+        $this->transactional = true;
+    }
+
+    private function getEntityName(): string
+    {
+        if ($this->entity instanceof ReportModel) {
+            return 'Report';
+        } else {
+            return explode_pop('\\', get_class($this->entity));
+        }
+    }
+
+    private function getEntityStatus(): ?string
+    {
+        if ($this->entity->status == EntityStatusStateMachine::NEEDS_MORE_INFORMATION ||
+            $this->entity->update_request_status == EntityStatusStateMachine::NEEDS_MORE_INFORMATION) {
+            return EntityStatusStateMachine::NEEDS_MORE_INFORMATION;
+        }
+
+        if ($this->entity->status == EntityStatusStateMachine::APPROVED) {
+            return EntityStatusStateMachine::APPROVED;
+        }
+
+        return null;
+    }
+
+    private function getSubject(): string
+    {
+        return match ($this->getEntityStatus()) {
+            EntityStatusStateMachine::APPROVED =>
+                'Your ' . $this->getEntityName() . ' Has Been Approved',
+            EntityStatusStateMachine::NEEDS_MORE_INFORMATION =>
+                'There is More Information Requested About Your ' . $this->getEntityName(),
+            default => '',
+        };
+    }
+
+    private function getFeedback(): ?string
+    {
+        if ($this->entity->update_request_status == EntityStatusStateMachine::APPROVED ||
+            $this->entity->update_request_status == EntityStatusStateMachine::NEEDS_MORE_INFORMATION) {
+            $feedback = $this
+                ->entity
+                ->updateRequests()
+                ->orderBy('updated_at', 'DESC')
+                ->first()
+                ->feedback;
+        } else {
+            $feedback = $this->entity->feedback;
+        }
+
+        return empty($feedback) ? null : $feedback;
+    }
+
+    private function getBodyParagraphs(): Collection
+    {
+        $paragraphs = collect();
+        if ($this->entity instanceof ReportModel) {
+            $paragraphs->push('Thank you for submitting your ' .
+                $this->entity->parentEntity()->pluck('name')->first() .
+                ' report.');
+        } else {
+            $paragraphs->push('Thank you for submitting your ' .
+                strtolower($this->getEntityName()) .
+                ' information.');
+        }
+
+        $paragraphs->push(match ($this->getEntityStatus()) {
+            EntityStatusStateMachine::APPROVED => [
+                'The information has been reviewed by your project manager and has been approved.',
+                $this->getFeedback(),
+            ],
+            EntityStatusStateMachine::NEEDS_MORE_INFORMATION => [
+                'The information has been reviewed by your project manager and they would like to see the following updates:',
+                $this->getFeedback() ?? '(No feedback)'
+            ],
+            default => null
+        });
+
+        $paragraphs->push('If you have any additional questions please reach out to your project manager or to info@terramatch.org');
+
+        return $paragraphs->flatten()->filter();
+    }
+}

--- a/app/Models/Traits/HasEntityStatusScopesAndTransitions.php
+++ b/app/Models/Traits/HasEntityStatusScopesAndTransitions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\StateMachines\EntityStatusStateMachine;
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasEntityStatusScopesAndTransitions {
+    public function scopeIsApproved(Builder $query): Builder
+    {
+        return $this->scopeIsStatus($query, EntityStatusStateMachine::APPROVED);
+    }
+
+    public function isEditable(): bool
+    {
+        return $this->status == EntityStatusStateMachine::STARTED;
+    }
+
+    public function approve($feedback): void
+    {
+        $this->feedback = $feedback;
+        $this->feedback_fields = null;
+
+        if ($this->status == EntityStatusStateMachine::APPROVED) {
+            // If we were already approved, this may have been called because an update request got approved, and
+            // we need to make sure the transition hooks execute, so fake us into awaiting-approval first.
+            $this->status = EntityStatusStateMachine::AWAITING_APPROVAL;
+        }
+
+        $this->status()->transitionTo(EntityStatusStateMachine::APPROVED);
+    }
+
+    public function submitForApproval(): void
+    {
+        $this->status()->transitionTo(EntityStatusStateMachine::AWAITING_APPROVAL);
+    }
+
+    public function needsMoreInformation($feedback, $feedbackFields): void
+    {
+        $this->feedback = $feedback;
+        $this->feedback_fields = $feedbackFields;
+        $this->status()->transitionTo(EntityStatusStateMachine::NEEDS_MORE_INFORMATION);
+    }
+}

--- a/app/Models/Traits/HasReportStatus.php
+++ b/app/Models/Traits/HasReportStatus.php
@@ -7,10 +7,13 @@ use App\StateMachines\ReportStatusStateMachine;
 use Asantibanez\LaravelEloquentStateMachines\Traits\HasStateMachines;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 /**
  * @property \Illuminate\Support\Carbon $submitted_at
+ * @property string $uuid
  * @property string $status
+ * @property string $update_request_status
  * @property string $feedback
  * @property string $feedback_fields
  * @property bool $nothing_to_report
@@ -170,5 +173,10 @@ trait HasReportStatus {
     public function dispatchStatusChangeEvent($user): void
     {
         EntityStatusChangeEvent::dispatch($user, $this);
+    }
+
+    public function getViewLinkPath(): string
+    {
+        return '/reports/' . Str::kebab(explode_pop('\\', get_class($this))) . '/' . $this->uuid;
     }
 }

--- a/app/Models/V2/EntityModel.php
+++ b/app/Models/V2/EntityModel.php
@@ -28,4 +28,6 @@ interface EntityModel extends UpdateRequestableModel, ApprovalFlow
     public function isEditable(): bool;
 
     public function dispatchStatusChangeEvent($user): void;
+
+    public function getViewLinkPath(): string;
 }

--- a/app/Models/V2/Nurseries/NurseryReport.php
+++ b/app/Models/V2/Nurseries/NurseryReport.php
@@ -241,4 +241,9 @@ class NurseryReport extends Model implements HasMedia, AuditableContract, Report
     {
         return true;
     }
+
+    public function parentEntity(): BelongsTo
+    {
+        return $this->nursery();
+    }
 }

--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -431,6 +431,8 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
      */
     private function submittedSiteReports(): HasManyThrough
     {
+        // scopes that use status don't work on the HasManyThrough because both Site and SiteReport have
+        // a status field.
         return $this
             ->siteReports()
             ->where('v2_sites.status', EntityStatusStateMachine::APPROVED)
@@ -443,8 +445,6 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
      */
     private function submittedSiteReportIds(): array
     {
-        // scopes that use status don't work on the HasManyThrough because both Site and SiteReport have
-        // a status field.
         return $this->submittedSiteReports()->pluck('v2_site_reports.id')->toArray();
     }
 }

--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -417,6 +417,12 @@ class Project extends Model implements HasMedia, AuditableContract, EntityModel
             : $query->doesntHave('monitoring');
     }
 
+    // All Entities are expected to have a project attribute.
+    public function getProjectAttribute(): Project
+    {
+        return $this;
+    }
+
     /** SEARCH */
     public function toSearchableArray()
     {

--- a/app/Models/V2/Projects/ProjectReport.php
+++ b/app/Models/V2/Projects/ProjectReport.php
@@ -431,4 +431,9 @@ class ProjectReport extends Model implements HasMedia, AuditableContract, Report
     {
         return $query->where('project_id', $id);
     }
+
+    public function parentEntity(): BelongsTo
+    {
+        return $this->project();
+    }
 }

--- a/app/Models/V2/ReportModel.php
+++ b/app/Models/V2/ReportModel.php
@@ -3,6 +3,7 @@
 namespace App\Models\V2;
 
 use App\Models\V2\Tasks\Task;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property Task task
@@ -12,4 +13,6 @@ interface ReportModel extends EntityModel
     public function nothingToReport();
 
     public function updateInProgress();
+
+    public function parentEntity(): BelongsTo;
 }

--- a/app/Models/V2/Sites/SiteReport.php
+++ b/app/Models/V2/Sites/SiteReport.php
@@ -350,4 +350,9 @@ class SiteReport extends Model implements HasMedia, AuditableContract, ReportMod
     {
         return new SiteReportResource($this);
     }
+
+    public function parentEntity(): BelongsTo
+    {
+        return $this->site();
+    }
 }

--- a/app/StateMachines/ReportStatusStateMachine.php
+++ b/app/StateMachines/ReportStatusStateMachine.php
@@ -45,11 +45,18 @@ class ReportStatusStateMachine extends EntityStatusStateMachine
 
     public function afterTransitionHooks(): array
     {
+        $hooks = parent::afterTransitionHooks();
+
         $updateTaskStatus = fn ($fromStatus, $model) => $model->task?->checkStatus();
-        return [
-            self::NEEDS_MORE_INFORMATION => [$updateTaskStatus],
-            self::AWAITING_APPROVAL => [$updateTaskStatus],
-            self::APPROVED => [$updateTaskStatus],
-        ];
+        $hooks[self::NEEDS_MORE_INFORMATION][] = $updateTaskStatus;
+        $hooks[self::AWAITING_APPROVAL][] = $updateTaskStatus;
+        $hooks[self::APPROVED][] = $updateTaskStatus;
+
+        return $hooks;
+    }
+
+    private function addHook ($hooks, $status, $hook)
+    {
+        $hooks[$status] = [$hook];
     }
 }


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-702

This includes an update to isolate email sends on lower envs by setting an `EMAIL_RECIPIENTS` ENV variable. When set, all emails are sent to that list instead of to the originally intended recipient in order to avoid spamming real users from lower envs.