### PR TITLE
[TM-745] Only return in-progress UpdateRequests from the endpoint.

### DIFF
--- a/app/Http/Controllers/V2/UpdateRequests/EntityUpdateRequestsController.php
+++ b/app/Http/Controllers/V2/UpdateRequests/EntityUpdateRequestsController.php
@@ -19,9 +19,7 @@ class EntityUpdateRequestsController extends Controller
     public function __invoke(Request $request, EntityModel $entity)
     {
         $this->authorize('read', $entity);
-        $latest = $entity->updateRequests()
-            ->orderBy('updated_at', 'DESC')
-            ->first();
+        $latest = $entity->updateRequests()->isUnapproved()->orderBy('updated_at', 'DESC')->first();
 
         if (is_null($latest)) {
             return new JsonResponse('There is not any update request for this resource', 404);


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-745

In order to support update request drafts, I changed the FE to always try to pull an update request from the BE even if we're not in an explicit "responding to feedback" flow. I didn't realize at the time that the DB is littered with update requests from before Nov 25 that have data formatted in a way that's no longer supported. There were a handful of undeleted update requests not in `approved` that are addressed manually in the ticket comments. For the rest, we can simply avoid sending `approved` change requests from this endpoint, which is appropriate anyway because once an update request is approved, it's no longer relevant for editing flows.