### PR TITLE
[TM-748] re-instate ability to put site reports into the nothing to report state.

### DIFF
--- a/app/Models/V2/Sites/SiteReport.php
+++ b/app/Models/V2/Sites/SiteReport.php
@@ -351,6 +351,11 @@ class SiteReport extends Model implements HasMedia, AuditableContract, ReportMod
         return new SiteReportResource($this);
     }
 
+    public function supportsNothingToReport(): bool
+    {
+        return true;
+    }
+
     public function parentEntity(): BelongsTo
     {
         return $this->site();


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-748

This method was removed accidentally in an earlier PR.