### PR TITLE
[TM-950] Allow the collection for linked fields to get stored in the DB form question

### DIFF
--- a/app/Http/Requests/V2/Forms/StoreFormRequest.php
+++ b/app/Http/Requests/V2/Forms/StoreFormRequest.php
@@ -34,6 +34,7 @@ class StoreFormRequest extends FormRequest
 
             'form_sections.*.form_questions' => ['sometimes', 'array'],
             'form_sections.*.form_questions.*.linked_field_key' => ['sometimes', 'nullable', 'string'],
+            'form_sections.*.form_questions.*.collection' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.label' => ['required', 'string'],
             'form_sections.*.form_questions.*.input_type' => ['sometimes', 'nullable'],
             'form_sections.*.form_questions.*.name' => ['sometimes', 'nullable'],
@@ -58,6 +59,7 @@ class StoreFormRequest extends FormRequest
 
             'form_sections.*.form_questions.*.child_form_questions' => ['sometimes'],
             'form_sections.*.form_questions.*.child_form_questions.*.linked_field_key' => ['sometimes', 'required', 'string'],
+            'form_sections.*.form_questions.*.child_form_questions.*.collection' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.child_form_questions.*.label' => ['sometimes', 'required', 'string'],
             'form_sections.*.form_questions.*.child_form_questions.*.name' => ['sometimes', 'nullable'],
             'form_sections.*.form_questions.*.child_form_questions.*.input_type' => ['sometimes', 'nullable'],

--- a/app/Http/Requests/V2/Forms/UpdateFormRequest.php
+++ b/app/Http/Requests/V2/Forms/UpdateFormRequest.php
@@ -34,6 +34,7 @@ class UpdateFormRequest extends FormRequest
 
             'form_sections.*.form_questions' => ['sometimes', 'nullable', 'array'],
             'form_sections.*.form_questions.*.linked_field_key' => ['sometimes', 'nullable', 'string'],
+            'form_sections.*.form_questions.*.collection' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.label' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.uuid' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.name' => ['sometimes', 'nullable'],
@@ -63,6 +64,7 @@ class UpdateFormRequest extends FormRequest
             'form_sections.*.form_questions.*.child_form_questions' => ['sometimes', 'nullable'],
             'form_sections.*.form_questions.*.child_form_questions.*.uuid' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.child_form_questions.*.linked_field_key' => ['sometimes', 'nullable', 'string'],
+            'form_sections.*.form_questions.*.child_form_questions.*.collection' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.child_form_questions.*.label' => ['sometimes', 'nullable', 'string'],
             'form_sections.*.form_questions.*.child_form_questions.*.name' => ['sometimes', 'nullable'],
             'form_sections.*.form_questions.*.child_form_questions.*.input_type' => ['sometimes', 'nullable'],


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-950

This fix also included some manual data fixing in prod, but this was the underlying cause. The `collection` for linked field questions like tree species wasn't getting included in the form question, which meant that it wasn't getting included on the data sent to the server when tree species were edited.