### PR TITLE
[TM-944] Enable polygon audit log

### DIFF
--- a/app/Http/Controllers/V2/Polygons/ViewAllSitesPolygonsForProjectController.php
+++ b/app/Http/Controllers/V2/Polygons/ViewAllSitesPolygonsForProjectController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\V2\Polygons;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\V2\SitePolygon\SitePolygonResource;
+use App\Models\V2\Projects\Project;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ViewAllSitesPolygonsForProjectController extends Controller
+{
+    public function __invoke(Request $request, Project $project): ResourceCollection
+    {
+        $sitePolygons = $project->with('sitePolygons')->get()->pluck('sitePolygons')->flatten();
+
+        return SitePolygonResource::collection($sitePolygons);
+    }
+}

--- a/app/Http/Resources/V2/SitePolygon/SitePolygonResource.php
+++ b/app/Http/Resources/V2/SitePolygon/SitePolygonResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources\V2\SitePolygon;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SitePolygonResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'uuid' => $this->uuid,
+            'poly_name' => $this->poly_name,
+            'status' => $this->status,
+            'date_created' => $this->date_created,
+            'created_by' => $this->created_by,
+        ];
+    }
+}

--- a/openapi-src/V2/definitions/SitePolygonResource.yml
+++ b/openapi-src/V2/definitions/SitePolygonResource.yml
@@ -1,0 +1,16 @@
+title: SitePolygonResource
+type: object
+properties:
+  id:
+    type: integer
+  uuid:
+    type: string
+  poly_name:
+    type: string
+  status:
+    type: string
+  date_created:
+    type: string
+    format: date-time
+  created_by:
+    type: string

--- a/openapi-src/V2/definitions/_index.yml
+++ b/openapi-src/V2/definitions/_index.yml
@@ -324,3 +324,5 @@ GeojsonData:
   $ref: './GeojsonData.yml'
 EntityTypeResponse:
   $ref: './EntityTypeResponse.yml'
+SitePolygonResource:
+  $ref: './SitePolygonResource.yml'

--- a/openapi-src/V2/paths/Projects/get-v2-projects-uuid-site-polygons-all.yml
+++ b/openapi-src/V2/paths/Projects/get-v2-projects-uuid-site-polygons-all.yml
@@ -1,0 +1,15 @@
+summary: Get all the SitePolygons from all sites belonging to a specific project
+operationId: get-v2-projects-uuid-site-polygons-all
+tags:
+  - V2 Projects
+  - V2 Sites
+  - V2 SitePolygons
+produces:
+  - application/json
+responses:
+  '200':
+    description: OK
+    schema:
+      type: array
+      items:
+        $ref: '../../definitions/_index.yml#/SitePolygonResource'

--- a/openapi-src/V2/paths/_index.yml
+++ b/openapi-src/V2/paths/_index.yml
@@ -2604,3 +2604,6 @@
 /v2/type-entity:
   get:
     $ref: './Entity/get-v2-type-entity.yml'
+/v2/projects/{UUID}/site-polygons/all:
+  get:
+    $ref: './Projects/get-v2-projects-uuid-site-polygons-all.yml'

--- a/resources/docs/swagger-v2.yml
+++ b/resources/docs/swagger-v2.yml
@@ -44717,6 +44717,23 @@ definitions:
         items:
           type: number
         description: Bounding box of the entity
+  SitePolygonResource:
+    title: SitePolygonResource
+    type: object
+    properties:
+      id:
+        type: integer
+      uuid:
+        type: string
+      poly_name:
+        type: string
+      status:
+        type: string
+      date_created:
+        type: string
+        format: date-time
+      created_by:
+        type: string
 paths:
   '/v2/tree-species/{entity}/{UUID}':
     get:
@@ -95911,3 +95928,35 @@ paths:
               error:
                 type: string
                 description: Error message
+  '/v2/projects/{UUID}/site-polygons/all':
+    get:
+      summary: Get all the SitePolygons from all sites belonging to a specific project
+      operationId: get-v2-projects-uuid-site-polygons-all
+      tags:
+        - V2 Projects
+        - V2 Sites
+        - V2 SitePolygons
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              title: SitePolygonResource
+              type: object
+              properties:
+                id:
+                  type: integer
+                uuid:
+                  type: string
+                poly_name:
+                  type: string
+                status:
+                  type: string
+                date_created:
+                  type: string
+                  format: date-time
+                created_by:
+                  type: string

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -120,6 +120,7 @@ use App\Http\Controllers\V2\Organisations\ViewOrganisationTasksController;
 use App\Http\Controllers\V2\OwnershipStake\DeleteOwnershipStakeController;
 use App\Http\Controllers\V2\OwnershipStake\StoreOwnershipStakeController;
 use App\Http\Controllers\V2\OwnershipStake\UpdateOwnershipStakeController;
+use App\Http\Controllers\V2\Polygons\ViewAllSitesPolygonsForProjectController;
 use App\Http\Controllers\V2\Polygons\ViewSitesPolygonsForProjectController;
 use App\Http\Controllers\V2\ProjectPitches\AdminIndexProjectPitchController;
 use App\Http\Controllers\V2\ProjectPitches\DeleteProjectPitchController;
@@ -524,6 +525,7 @@ Route::prefix('projects')->group(function () {
     Route::get('/{project}/partners', ViewProjectMonitoringPartnersController::class);
     Route::get('/{project}/sites', ViewProjectSitesController::class);
     Route::get('/{project}/site-polygons', ViewSitesPolygonsForProjectController::class);
+    Route::get('/{project}/site-polygons/all', ViewAllSitesPolygonsForProjectController::class);
     Route::get('/{project}/nurseries', ViewProjectNurseriesController::class);
     Route::get('/{project}/files', ViewProjectGalleryController::class);
     Route::get('/{project}/monitorings', ViewAProjectsMonitoringsController::class);


### PR DESCRIPTION
[Task Link](https://gfw.atlassian.net/browse/TM-944)

A new endpoint for listing all the `SitePolygon` entities related to a given `Project` through `Site`:

Note:
`api/v2/projects/{project}/site-polygons` is returning among other things the geojson of the site table.

While the new endpoint
`api/v2/projects/{project}/site-polygons/all` is returning all needed information from `SitePolygon` table.