### PR TITLE
[TM-1103] Fix framework permissions

### DIFF
--- a/config/wri/permissions.php
+++ b/config/wri/permissions.php
@@ -5,6 +5,7 @@ return [
         'framework-ppc' => 'Framework PPC',
         'framework-terrafund' => 'Framework Terrafund',
         'framework-terrafund-enterprises' => 'Framework Terrafund Enterprises',
+        'framework-terrafund-landscapes' => 'Framework Terrafund Landscapes',
         'framework-hbf' => 'Framework Harit Bharat Fund',
         'custom-forms-manage' => 'Manage custom forms',
         'users-manage' => 'Manage users',
@@ -22,6 +23,7 @@ return [
             'framework-terrafund',
             'framework-ppc',
             'framework-terrafund-enterprises',
+            'framework-terrafund-landscapes',
             'framework-hbf',
             'custom-forms-manage',
             'users-manage',
@@ -38,6 +40,7 @@ return [
         'admin-terrafund' => [
             'framework-terrafund',
             'framework-terrafund-enterprises',
+            'framework-terrafund-landscapes',
             'custom-forms-manage',
             'users-manage',
             'monitoring-manage',

--- a/config/wri/permissions.php
+++ b/config/wri/permissions.php
@@ -4,7 +4,7 @@ return [
     'permissions' => [
         'framework-ppc' => 'Framework PPC',
         'framework-terrafund' => 'Framework Terrafund',
-        'framework-terrafund-enterprises' => 'Framework Terrafund Enterprises',
+        'framework-enterprises' => 'Framework Terrafund Enterprises',
         'framework-terrafund-landscapes' => 'Framework Terrafund Landscapes',
         'framework-hbf' => 'Framework Harit Bharat Fund',
         'custom-forms-manage' => 'Manage custom forms',
@@ -22,7 +22,7 @@ return [
         'admin-super' => [
             'framework-terrafund',
             'framework-ppc',
-            'framework-terrafund-enterprises',
+            'framework-enterprises',
             'framework-terrafund-landscapes',
             'framework-hbf',
             'custom-forms-manage',
@@ -39,7 +39,7 @@ return [
         ],
         'admin-terrafund' => [
             'framework-terrafund',
-            'framework-terrafund-enterprises',
+            'framework-enterprises',
             'framework-terrafund-landscapes',
             'custom-forms-manage',
             'users-manage',


### PR DESCRIPTION
* The Landscapes framework had never been added to the permissions file.
* The Enterprises framework was incorrectly specified in the permissions file.