### PR TITLE
[TM-1262] The string being passed in here is now the slug, not the access code.

### DIFF
--- a/app/Http/Controllers/V2/Exports/ExportAllMonitoredEntitiesController.php
+++ b/app/Http/Controllers/V2/Exports/ExportAllMonitoredEntitiesController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\V2\Exports;
 
 use App\Http\Controllers\Controller;
-use App\Models\Framework;
 use App\Models\V2\Forms\Form;
 use App\Models\V2\Nurseries\Nursery;
 use App\Models\V2\Nurseries\NurseryReport;
@@ -21,7 +20,6 @@ class ExportAllMonitoredEntitiesController extends Controller
     public function __invoke(Request $request, string $entity, string $framework)
     {
         $modelClass = $this->getModelClass($entity);
-        $framework = $this->getSlug($framework);
         $form = $this->getForm($modelClass, $framework);
         $this->authorize('export', [$modelClass, $form]);
 
@@ -36,13 +34,6 @@ class ExportAllMonitoredEntitiesController extends Controller
         }, $filename, [
             'Content-Type' => 'text/csv',
         ]);
-    }
-
-    private function getSlug(string $framework)
-    {
-        $frameworkModel = Framework::where('access_code', $framework)->firstOrFail();
-
-        return $frameworkModel->slug;
     }
 
     private function getForm(string $modelClass, string $framework)


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1262

What's going on here is that the FE used to get its list of frameworks for an API endpoint that returns access codes instead of slugs, but now it's coming from the list of slugs on the `auth/me` object. Slugs are the better thing to be passing around here, so I simply rolled back the change from April that supported access codes. This wasn't caught in testing because for most frameworks, the access code and the slug are the same. It was caught in prod because that's not true for TF Landscapes.