### PR TITLE
[TM-1263] Ignore hidden data

### DIFF
--- a/app/Console/Commands/OneOff/BackfillHidden.php
+++ b/app/Console/Commands/OneOff/BackfillHidden.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Console\Commands\OneOff;
+
+use App\Models\V2\Nurseries\NurseryReport;
+use App\Models\V2\Projects\ProjectReport;
+use App\Models\V2\Sites\SiteReport;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class BackfillHidden extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'one-off:backfill-hidden';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fills the \'hidden\' field of report-associated models based on form responses';
+
+    private const REPORT_TYPES = [
+        ProjectReport::class,
+        SiteReport::class,
+        NurseryReport::class,
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $count = 0;
+        foreach (self::REPORT_TYPES as $reportType) {
+            $count += $reportType::count();
+        }
+        $bar = $this->output->createProgressBar($count);
+        $bar->start();
+
+        $hidden = [];
+        foreach (self::REPORT_TYPES as $reportType) {
+            $reportType::chunkById(100, function ($reports) use ($bar, &$hidden) {
+                foreach ($reports as $report) {
+                    $this->findRelationsToHide($report, $hidden);
+                    $bar->advance();
+                }
+            });
+        }
+        $bar->finish();
+
+        $this->info("\n\nHidden: \n" . json_encode($hidden, JSON_PRETTY_PRINT));
+    }
+
+    protected function findRelationsToHide($entity, &$hidden)
+    {
+        $questions = $entity->getForm()->sections->map(fn ($section) => $section->questions)->flatten();
+        $formConfig = $entity->getFormConfig();
+        $linkedFieldQuestions = $questions->filter(function ($question) use ($formConfig) {
+            $property = data_get($formConfig, "relations.$question->linked_field_key.property");
+
+            return ! empty($property) && ! empty($question->parent_id);
+        });
+
+        foreach ($linkedFieldQuestions as $question) {
+            if (empty($entity->answers) || $entity->answers[$question->parent_id] !== false) {
+                continue;
+            }
+
+            $relation = $entity->{$question->input_type}();
+            $collection = $question->collection;
+            if (! empty($collection)) {
+                $relation->where('collection', $collection);
+            }
+
+            $count = $relation->count();
+            if ($count > 0) {
+                $relation->update(['hidden' => true, 'updated_at' => DB::raw('updated_at')]);
+
+                $hidden[] = [
+                    'entity_type' => get_class($entity),
+                    'entity_uuid' => $entity->uuid,
+                    'type' => $question->input_type,
+                    'collection' => $collection,
+                ];
+            }
+        }
+    }
+}

--- a/app/Models/Interfaces/HandlesLinkedFieldSync.php
+++ b/app/Models/Interfaces/HandlesLinkedFieldSync.php
@@ -6,5 +6,5 @@ use App\Models\V2\EntityModel;
 
 interface HandlesLinkedFieldSync
 {
-    public static function syncRelation(EntityModel $entity, string $property, $data): void;
+    public static function syncRelation(EntityModel $entity, string $property, $data, bool $hidden): void;
 }

--- a/app/Models/Traits/HasWorkdays.php
+++ b/app/Models/Traits/HasWorkdays.php
@@ -73,7 +73,9 @@ trait HasWorkdays
     protected function sumTotalWorkdaysAmounts(array $collections): int
     {
         // Assume that the types are balanced, and just return the value from `gender`
-        return WorkdayDemographic::whereIn('workday_id', $this->workdays()->collections($collections)->select('id'))
-            ->gender()->sum('amount');
+        return WorkdayDemographic::whereIn(
+            'workday_id',
+            $this->workdays()->visible()->collections($collections)->select('id')
+        )->gender()->sum('amount');
     }
 }

--- a/app/Models/V2/Disturbance.php
+++ b/app/Models/V2/Disturbance.php
@@ -5,6 +5,7 @@ namespace App\Models\V2;
 use App\Http\Resources\V2\Disturbances\DisturbanceCollection;
 use App\Models\Traits\HasTypes;
 use App\Models\Traits\HasUuid;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -56,5 +57,10 @@ class Disturbance extends Model implements EntityRelationModel
     public function disturbanceable()
     {
         return $this->morphTo();
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 }

--- a/app/Models/V2/Disturbance.php
+++ b/app/Models/V2/Disturbance.php
@@ -28,9 +28,14 @@ class Disturbance extends Model implements EntityRelationModel
         'description',
         'disturbanceable_type',
         'disturbanceable_id',
+        'hidden',
 
         'old_id',
         'old_model',
+    ];
+
+    protected $casts = [
+        'hidden' => 'boolean',
     ];
 
     public static function createResourceCollection(EntityModel $entity): JsonResource

--- a/app/Models/V2/Invasive.php
+++ b/app/Models/V2/Invasive.php
@@ -25,9 +25,14 @@ class Invasive extends Model implements EntityRelationModel
         'collection',
         'invasiveable_type',
         'invasiveable_id',
+        'hidden',
 
         'old_id',
         'old_model',
+    ];
+
+    protected $casts = [
+        'hidden' => 'boolean',
     ];
 
     public static function createResourceCollection(EntityModel $entity): JsonResource

--- a/app/Models/V2/Invasive.php
+++ b/app/Models/V2/Invasive.php
@@ -5,6 +5,7 @@ namespace App\Models\V2;
 use App\Http\Resources\V2\Invasives\InvasiveCollection;
 use App\Models\Traits\HasTypes;
 use App\Models\Traits\HasUuid;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -52,5 +53,10 @@ class Invasive extends Model implements EntityRelationModel
     public function invasiveable()
     {
         return $this->morphTo();
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 }

--- a/app/Models/V2/Projects/Project.php
+++ b/app/Models/V2/Projects/Project.php
@@ -351,6 +351,7 @@ class Project extends Model implements MediaModel, AuditableContract, EntityMode
         return TreeSpecies::where('speciesable_type', SiteReport::class)
             ->whereIn('speciesable_id', $this->submittedSiteReportIds())
             ->where('collection', TreeSpecies::COLLECTION_PLANTED)
+            ->visible()
             ->sum('amount');
     }
 
@@ -358,6 +359,7 @@ class Project extends Model implements MediaModel, AuditableContract, EntityMode
     {
         return Seeding::where('seedable_type', SiteReport::class)
             ->whereIn('seedable_id', $this->submittedSiteReportIds())
+            ->visible()
             ->sum('amount');
     }
 
@@ -379,11 +381,13 @@ class Project extends Model implements MediaModel, AuditableContract, EntityMode
             'workday_id',
             Workday::where('workdayable_type', SiteReport::class)
                 ->whereIn('workdayable_id', $siteQuery->select('v2_site_reports.id'))
+                ->visible()
                 ->select('id')
         )->orWhereIn(
             'workday_id',
             Workday::where('workdayable_type', ProjectReport::class)
                 ->whereIn('workdayable_id', $projectQuery->select('id'))
+                ->visible()
                 ->select('id')
         )->gender()->sum('amount') ?? 0;
     }

--- a/app/Models/V2/Projects/ProjectReport.php
+++ b/app/Models/V2/Projects/ProjectReport.php
@@ -294,7 +294,7 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
     public function getSeedlingsGrownAttribute(): int
     {
         if ($this->framework_key == 'ppc') {
-            return $this->treeSpecies()->sum('amount');
+            return $this->treeSpecies()->visible()->sum('amount');
         }
 
         if ($this->framework_key == 'terrafund') {
@@ -316,6 +316,7 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
                     'speciesable_id',
                     $this->project->reports()->where('created_at', '<=', $this->created_at)->select('id')
                 )
+                ->visible()
                 ->sum('amount');
         }
 
@@ -332,6 +333,7 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
         return TreeSpecies::where('speciesable_type', SiteReport::class)
             ->whereIn('speciesable_id', $this->task->siteReports()->select('id'))
             ->where('collection', TreeSpecies::COLLECTION_PLANTED)
+            ->visible()
             ->sum('amount');
     }
 
@@ -343,6 +345,7 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
 
         return Seeding::where('seedable_type', SiteReport::class)
             ->whereIn('seedable_id', $this->task->siteReports()->select('id'))
+            ->visible()
             ->sum('amount');
     }
 
@@ -368,6 +371,7 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
             Workday::where('workdayable_type', SiteReport::class)
                 ->whereIn('workdayable_id', $this->task->siteReports()->hasBeenSubmitted()->select('id'))
                 ->collections(SiteReport::WORKDAY_COLLECTIONS[$collectionType])
+                ->visible()
                 ->select('id')
         )->gender()->sum('amount');
 

--- a/app/Models/V2/Seeding.php
+++ b/app/Models/V2/Seeding.php
@@ -24,8 +24,14 @@ class Seeding extends Model implements EntityRelationModel
         'amount',
         'seedable_type',
         'seedable_id',
+        'hidden',
+
         'old_id',
         'old_model',
+    ];
+
+    protected $casts = [
+        'hidden' => 'boolean',
     ];
 
     public static function createResourceCollection(EntityModel $entity): JsonResource

--- a/app/Models/V2/Seeding.php
+++ b/app/Models/V2/Seeding.php
@@ -4,6 +4,7 @@ namespace App\Models\V2;
 
 use App\Http\Resources\V2\Seedings\SeedingsCollection;
 use App\Models\Traits\HasUuid;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -51,5 +52,10 @@ class Seeding extends Model implements EntityRelationModel
     public function seedable()
     {
         return $this->morphTo();
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 }

--- a/app/Models/V2/Sites/Site.php
+++ b/app/Models/V2/Sites/Site.php
@@ -299,6 +299,7 @@ class Site extends Model implements MediaModel, AuditableContract, EntityModel, 
 
         return Seeding::where('seedable_type', SiteReport::class)
             ->whereIn('seedable_id', $submissionsIds)
+            ->visible()
             ->sum('amount');
     }
 
@@ -330,6 +331,7 @@ class Site extends Model implements MediaModel, AuditableContract, EntityModel, 
         return TreeSpecies::where('speciesable_type', SiteReport::class)
             ->whereIn('speciesable_id', $reportIds)
             ->where('collection', TreeSpecies::COLLECTION_PLANTED)
+            ->visible()
             ->sum('amount');
     }
 
@@ -349,6 +351,7 @@ class Site extends Model implements MediaModel, AuditableContract, EntityModel, 
             'workday_id',
             Workday::where('workdayable_type', SiteReport::class)
                 ->whereIn('workdayable_id', $reportQuery->select('id'))
+                ->visible()
                 ->select('id')
         )->gender()->sum('amount') ?? 0;
     }

--- a/app/Models/V2/Sites/SiteReport.php
+++ b/app/Models/V2/Sites/SiteReport.php
@@ -282,12 +282,12 @@ class SiteReport extends Model implements MediaModel, AuditableContract, ReportM
 
     public function getTotalTreesPlantedCountAttribute(): int
     {
-        return $this->treeSpecies()->sum('amount');
+        return $this->treeSpecies()->visible()->sum('amount');
     }
 
     public function getTotalSeedsPlantedCountAttribute(): int
     {
-        return $this->seedings()->sum('amount');
+        return $this->seedings()->visible()->sum('amount');
     }
 
     public function getOrganisationAttribute()

--- a/app/Models/V2/Stratas/Strata.php
+++ b/app/Models/V2/Stratas/Strata.php
@@ -21,6 +21,7 @@ class Strata extends Model implements EntityRelationModel
 
     protected $casts = [
         'published' => 'boolean',
+        'hidden' => 'boolean',
     ];
 
     public $table = 'v2_stratas';
@@ -30,6 +31,7 @@ class Strata extends Model implements EntityRelationModel
         'stratasable_id',
         'description',
         'extent',
+        'hidden',
     ];
 
     public static function createResourceCollection(EntityModel $entity): JsonResource

--- a/app/Models/V2/Stratas/Strata.php
+++ b/app/Models/V2/Stratas/Strata.php
@@ -7,6 +7,7 @@ use App\Models\Traits\HasTypes;
 use App\Models\Traits\HasUuid;
 use App\Models\V2\EntityModel;
 use App\Models\V2\EntityRelationModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -51,5 +52,10 @@ class Strata extends Model implements EntityRelationModel
     public function stratasable()
     {
         return $this->morphTo();
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 }

--- a/app/Models/V2/TreeSpecies/TreeSpecies.php
+++ b/app/Models/V2/TreeSpecies/TreeSpecies.php
@@ -25,6 +25,7 @@ class TreeSpecies extends Model implements EntityRelationModel
 
     protected $casts = [
         'published' => 'boolean',
+        'hidden' => 'boolean',
     ];
 
     public $table = 'v2_tree_species';
@@ -35,6 +36,8 @@ class TreeSpecies extends Model implements EntityRelationModel
         'speciesable_type',
         'speciesable_id',
         'collection',
+        'hidden',
+
         'old_id',
         'old_model',
     ];

--- a/app/Models/V2/TreeSpecies/TreeSpecies.php
+++ b/app/Models/V2/TreeSpecies/TreeSpecies.php
@@ -7,6 +7,7 @@ use App\Models\Traits\HasTypes;
 use App\Models\Traits\HasUuid;
 use App\Models\V2\EntityModel;
 use App\Models\V2\EntityRelationModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -70,6 +71,11 @@ class TreeSpecies extends Model implements EntityRelationModel
         }
 
         return new TreeSpeciesCollection($query->paginate());
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 
     public function speciesable()

--- a/app/Models/V2/Workdays/Workday.php
+++ b/app/Models/V2/Workdays/Workday.php
@@ -27,6 +27,7 @@ class Workday extends Model implements HandlesLinkedFieldSync
 
     protected $casts = [
         'published' => 'boolean',
+        'hidden' => 'boolean',
     ];
 
     public $table = 'v2_workdays';
@@ -43,6 +44,7 @@ class Workday extends Model implements HandlesLinkedFieldSync
         'indigeneity',
         'migrated_to_demographics',
         'description',
+        'hidden',
     ];
 
     public const COLLECTION_PROJECT_PAID_NURSERY_OPERATIONS = 'paid-nursery-operations';

--- a/app/Models/V2/Workdays/Workday.php
+++ b/app/Models/V2/Workdays/Workday.php
@@ -90,7 +90,7 @@ class Workday extends Model implements HandlesLinkedFieldSync
     /**
      * @throws \Exception
      */
-    public static function syncRelation(EntityModel $entity, string $property, $data): void
+    public static function syncRelation(EntityModel $entity, string $property, $data, bool $hidden): void
     {
         if (count($data) == 0) {
             $entity->$property()->delete();
@@ -114,7 +114,10 @@ class Workday extends Model implements HandlesLinkedFieldSync
                 'workdayable_type' => get_class($entity),
                 'workdayable_id' => $entity->id,
                 'collection' => $workdayData['collection'],
+                'hidden' => $hidden,
             ]);
+        } else {
+            $workday->update(['hidden' => $hidden]);
         }
 
         // Make sure the incoming data is clean, and meets our expectations of one row per type/subtype/name combo.
@@ -185,6 +188,11 @@ class Workday extends Model implements HandlesLinkedFieldSync
     public function scopeCollections(Builder $query, array $collections): Builder
     {
         return $query->whereIn('collection', $collections);
+    }
+
+    public function scopeVisible($query): Builder
+    {
+        return $query->where('hidden', false);
     }
 
     public function demographics(): HasMany

--- a/database/migrations/2024_09_03_222951_add_hidden_to_entity_associations.php
+++ b/database/migrations/2024_09_03_222951_add_hidden_to_entity_associations.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    private const TABLES = [
+        'v2_tree_species',
+        'v2_disturbances',
+        'v2_workdays',
+        'v2_stratas',
+        'v2_invasives',
+        'v2_seedings',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->boolean('hidden')->default(false);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('hidden');
+            });
+        }
+    }
+};

--- a/tests/Unit/Models/V2/Workdays/WorkdayTest.php
+++ b/tests/Unit/Models/V2/Workdays/WorkdayTest.php
@@ -23,7 +23,7 @@ class WorkdayTest extends TestCase
                 ],
             ],
         ];
-        Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data);
+        Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data, false);
 
         $workday = $siteReport->workdaysVolunteerPlanting()->first();
         $this->assertEquals(3, $workday->demographics()->count());
@@ -38,7 +38,7 @@ class WorkdayTest extends TestCase
             ['type' => 'gender', 'name' => 'female', 'amount' => 20],
             ['type' => 'ethnicity', 'subtype' => 'indigenous', 'name' => 'Ohlone', 'amount' => 40],
         ];
-        Workday::syncRelation($siteReport->fresh(), 'workdaysVolunteerPlanting', $data);
+        Workday::syncRelation($siteReport->fresh(), 'workdaysVolunteerPlanting', $data, false);
         $workday->refresh();
         $this->assertEquals(4, $workday->demographics()->count());
         $this->assertEquals(40, $workday->demographics()->isAge('youth')->first()->amount);
@@ -48,7 +48,7 @@ class WorkdayTest extends TestCase
 
         // Test remove demographics
         $data[0]['demographics'] = [];
-        Workday::syncRelation($siteReport->fresh(), 'workdaysVolunteerPlanting', $data);
+        Workday::syncRelation($siteReport->fresh(), 'workdaysVolunteerPlanting', $data, false);
         $workday->refresh();
         $this->assertEquals(0, $workday->demographics()->count());
 
@@ -67,7 +67,7 @@ class WorkdayTest extends TestCase
             ],
         ];
         $siteReport = SiteReport::factory()->create();
-        Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data);
+        Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data, false);
 
         $workday = $siteReport->workdaysVolunteerPlanting()->first();
         $this->assertEquals(3, $workday->demographics()->count());


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1263

We have a general data problem with entity-associated tables (tree species, seedings, workdays, etc): if a PD or admin going through the form fills in some data, and then changes their mind and clicks "no" to the conditional, thus hiding the field, the data is still recorded in the DB, and then gets included in attributes that aggregate that data into counts on the API response or in exports. 

We could just delete that data when the form is submitted, but if the user clicked "no" by accident, we want them to be able to recover it by going back and clicking "yes" without having the type the numbers in again. So, I've added a column to these tables (`hidden`), which gets set to true when the form is submitted and the conditional is set to "no". Then, when aggregating data, we skip including numbers from any rows that have "hidden" set to true.