### PR TITLE
[TM-1197] Add site id validator in upload

### DIFF
--- a/app/Helpers/GeometryHelper.php
+++ b/app/Helpers/GeometryHelper.php
@@ -78,9 +78,6 @@ class GeometryHelper
                     'long' => $longitude,
                 ]);
 
-
-            Log::info("Centroid updated for projectUuid: $projectUuid");
-
             return response()->json([
               'message' => 'Centroid updated',
               'centroid' => $centroid,

--- a/app/Http/Controllers/V2/Terrafund/TerrafundEditGeometryController.php
+++ b/app/Http/Controllers/V2/Terrafund/TerrafundEditGeometryController.php
@@ -256,6 +256,9 @@ class TerrafundEditGeometryController extends Controller
 
             $user = Auth::user();
             $newPolygonVersion = $sitePolygon->createCopy($user, null, false, $validatedData);
+            if (! $newPolygonVersion) {
+                return response()->json(['error' => 'An error occurred while creating a new version of the site polygon'], 500);
+            }
             $newPolygonVersion->changeStatusOnEdit();
 
             return response()->json(['message' => 'Site polygon version created successfully'], 201);

--- a/app/Models/V2/Sites/SitePolygon.php
+++ b/app/Models/V2/Sites/SitePolygon.php
@@ -120,30 +120,32 @@ class SitePolygon extends Model implements AuditableModel
     {
         $geometry = $this->polygonGeometry()->first();
         SitePolygon::where('primary_uuid', $this->primary_uuid)->update(['is_active' => false]);
-        
+
         $newSitePolygon = $this->replicate();
         $currentSite = Site::where('uuid', $newSitePolygon->site_id)->exists();
         if (! $currentSite) {
-          if (isset($properties['site_id'])) {
-              $siteExists = Site::where('uuid', $properties['site_id'])->exists();
-              if (! $siteExists) {
-                  Log::info('Provided Site UUID not found = ' . $properties['site_id'] . " for SitePolygon UUID = " . $newSitePolygon->uuid);
-                  return null;
-              }
-              Log::info($this->primary_uuid."Changing sites from " . $newSitePolygon->site_id . " to " . $properties['site_id']);
-              $newSitePolygon->site_id = $properties['site_id'];
-          } else {
-              Log::info('Site UUID not found = ' . $newSitePolygon->site_id . " for SitePolygon UUID = " . $newSitePolygon->uuid);
-              return null;
-          }
-      }
+            if (isset($properties['site_id'])) {
+                $siteExists = Site::where('uuid', $properties['site_id'])->exists();
+                if (! $siteExists) {
+                    Log::info('Provided Site UUID not found = ' . $properties['site_id'] . ' for SitePolygon UUID = ' . $newSitePolygon->uuid);
+
+                    return null;
+                }
+                Log::info($this->primary_uuid.'Changing sites from ' . $newSitePolygon->site_id . ' to ' . $properties['site_id']);
+                $newSitePolygon->site_id = $properties['site_id'];
+            } else {
+                Log::info('Site UUID not found = ' . $newSitePolygon->site_id . ' for SitePolygon UUID = ' . $newSitePolygon->uuid);
+
+                return null;
+            }
+        }
 
         if (! $poly_id) {
-          $copyGeometry = PolygonGeometry::create([
-              'geom' => $geometry->geom,
-              'created_by' => $user->id,
-          ]);
-      }
+            $copyGeometry = PolygonGeometry::create([
+                'geom' => $geometry->geom,
+                'created_by' => $user->id,
+            ]);
+        }
         $newSitePolygon->primary_uuid = $this->primary_uuid;
         $newSitePolygon->plantstart = $properties['plantstart'] ?? $this->plantstart;
         $newSitePolygon->plantend = $properties['plantend'] ?? $this->plantend;

--- a/app/Models/V2/Sites/SitePolygon.php
+++ b/app/Models/V2/Sites/SitePolygon.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Znck\Eloquent\Relations\BelongsToThrough;
 use Znck\Eloquent\Traits\BelongsToThrough as BelongsToThroughTrait;
@@ -119,13 +120,30 @@ class SitePolygon extends Model implements AuditableModel
     {
         $geometry = $this->polygonGeometry()->first();
         SitePolygon::where('primary_uuid', $this->primary_uuid)->update(['is_active' => false]);
-        if (! $poly_id) {
-            $copyGeometry = PolygonGeometry::create([
-                'geom' => $geometry->geom,
-                'created_by' => $user->id,
-            ]);
-        }
+        
         $newSitePolygon = $this->replicate();
+        $currentSite = Site::where('uuid', $newSitePolygon->site_id)->exists();
+        if (! $currentSite) {
+          if (isset($properties['site_id'])) {
+              $siteExists = Site::where('uuid', $properties['site_id'])->exists();
+              if (! $siteExists) {
+                  Log::info('Provided Site UUID not found = ' . $properties['site_id'] . " for SitePolygon UUID = " . $newSitePolygon->uuid);
+                  return null;
+              }
+              Log::info($this->primary_uuid."Changing sites from " . $newSitePolygon->site_id . " to " . $properties['site_id']);
+              $newSitePolygon->site_id = $properties['site_id'];
+          } else {
+              Log::info('Site UUID not found = ' . $newSitePolygon->site_id . " for SitePolygon UUID = " . $newSitePolygon->uuid);
+              return null;
+          }
+      }
+
+        if (! $poly_id) {
+          $copyGeometry = PolygonGeometry::create([
+              'geom' => $geometry->geom,
+              'created_by' => $user->id,
+          ]);
+      }
         $newSitePolygon->primary_uuid = $this->primary_uuid;
         $newSitePolygon->plantstart = $properties['plantstart'] ?? $this->plantstart;
         $newSitePolygon->plantend = $properties['plantend'] ?? $this->plantend;

--- a/app/Services/PolygonService.php
+++ b/app/Services/PolygonService.php
@@ -292,7 +292,8 @@ class PolygonService
             $site = $sitePolygon->site()->first();
             if (! $site) {
                 Log::error('Site not found', ['site polygon uuid' => $sitePolygon->uuid, 'site id' => $sitePolygon->site_id]);
-                return response()->json(['error' => "Site not found"], Response::HTTP_INTERNAL_SERVER_ERROR);
+
+                return response()->json(['error' => 'Site not found'], Response::HTTP_INTERNAL_SERVER_ERROR);
             }
             $site->restorationInProgress();
             $project = $sitePolygon->project()->first();
@@ -326,6 +327,7 @@ class PolygonService
             $site = $newSitePolygon->site()->first();
             if (! $site) {
                 Log::error('Site not found', ['site polygon uuid' => $newSitePolygon->uuid, 'site id' => $newSitePolygon->site_id]);
+
                 return false;
 
             }


### PR DESCRIPTION
Adding site_id existence validator in creation of versions of polygons. 
If site_id dont exist will check if the site_id has the property to a existent site_id. 
This change of site_id will also preserve the status of previous version. 


