### PR TITLE
[TM-1414] Duplicate demographics

### DIFF
--- a/app/Models/V2/Workdays/Workday.php
+++ b/app/Models/V2/Workdays/Workday.php
@@ -151,11 +151,11 @@ class Workday extends Model implements HandlesLinkedFieldSync
         $demographics = $workday->demographics;
         $represented = collect();
         foreach ($syncData as $row) {
-            $demographic = $demographics->firstWhere([
-                'type' => data_get($row, 'type'),
-                'subtype' => data_get($row, 'subtype'),
-                'name' => data_get($row, 'name'),
-            ]);
+            $demographic = $demographics->first(fn ($dbRow) =>
+                data_get($dbRow, 'type') == data_get($row, 'type') &&
+                data_get($dbRow, 'subtype') == data_get($row, 'subtype') &&
+                data_get($dbRow, 'name') == data_get($row, 'name')
+            );
 
             if ($demographic == null) {
                 $workday->demographics()->create($row);

--- a/app/Models/V2/Workdays/Workday.php
+++ b/app/Models/V2/Workdays/Workday.php
@@ -148,28 +148,27 @@ class Workday extends Model implements HandlesLinkedFieldSync
             return $syncData;
         }, []) : [];
 
-        $demographics = $workday->demographics;
         $represented = collect();
         foreach ($syncData as $row) {
-            $demographic = $demographics->first(fn ($dbRow) =>
-                data_get($dbRow, 'type') == data_get($row, 'type') &&
-                data_get($dbRow, 'subtype') == data_get($row, 'subtype') &&
-                data_get($dbRow, 'name') == data_get($row, 'name')
-            );
+            // It's not great to fetch these individually, but this does help combat the possibility of a race condition
+            // from two HTTP threads (potentially on different servers) processing an update to this workday at the
+            // same time.
+            $demographic = $workday->demographics()->where([
+                'type' => data_get($row, 'type'),
+                'subtype' => data_get($row, 'subtype'),
+                'name' => data_get($row, 'name'),
+            ])->first();
 
             if ($demographic == null) {
-                $workday->demographics()->create($row);
+                $represented->push($workday->demographics()->create($row)->id);
             } else {
                 $represented->push($demographic->id);
                 $demographic->update(['amount' => data_get($row, 'amount')]);
             }
         }
+
         // Remove any existing demographic that wasn't in the submitted set.
-        foreach ($demographics as $demographic) {
-            if (! $represented->contains($demographic->id)) {
-                $demographic->delete();
-            }
-        }
+        $workday->demographics()->whereNotIn('id', $represented)->delete();
     }
 
     public function workdayable()

--- a/tests/Unit/Models/V2/Workdays/WorkdayTest.php
+++ b/tests/Unit/Models/V2/Workdays/WorkdayTest.php
@@ -68,9 +68,11 @@ class WorkdayTest extends TestCase
         ];
         $siteReport = SiteReport::factory()->create();
         Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data, false);
+        Workday::syncRelation($siteReport, 'workdaysVolunteerPlanting', $data, false);
 
         $workday = $siteReport->workdaysVolunteerPlanting()->first();
         $this->assertEquals(3, $workday->demographics()->count());
+        $this->assertEquals(3, $workday->demographics()->withTrashed()->count());
         $this->assertEquals(40, $workday->demographics()->isAge('youth')->first()->amount);
         $this->assertEquals(40, $workday->demographics()->isGender('non-binary')->first()->amount);
         $this->assertEquals(40, $workday->demographics()->isEthnicity('other')->first()->amount);


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1414

Two things going on here:
* The old code was flawed in how it was looking for existing rows to update, and was therefore deleting everything on an update and creating fresh.
* The old code was potentially suffering from a race condition. If multiple server threads were processing duplicate PUT requests for form update at the same time, it could cause the set of demographics to get duplicated. 

The fix for the second bullet point is a little less performant, but should be way more stable. Long term, we should address why the browser is sometimes issuing multiple form updates back to back, but I think that's something best addressed by the transition to v3, so we get this bandaid for now. 