### PR TITLE
[TM-1681] Isolate the demographic types possible on this endpoint.

### DIFF
--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -515,7 +515,7 @@ Route::get('/{entityType}/{uuid}/aggregate-reports', GetAggregateReportsControll
 
 ModelInterfaceBindingMiddleware::forSlugs(['project-report', 'site-report'], function () {
     Route::get('/{entity}', GetDemographicsForEntityController::class);
-}, prefix: '{demographicType}');
+}, prefix: '{demographicType}')->whereIn('demographicType', ['workdays', 'restoration-partners']);
 
 Route::prefix('leadership-team')->group(function () {
     Route::post('/', StoreLeadershipTeamController::class);


### PR DESCRIPTION
This fixes an API route collision between the demographics fetch endpoints and the update request endpoint, which follows the same pattern.