### PR TITLE
[TM-1962] Clean conditional data admin edit

### DIFF
--- a/app/Models/Traits/UsesLinkedFields.php
+++ b/app/Models/Traits/UsesLinkedFields.php
@@ -98,6 +98,13 @@ trait UsesLinkedFields
         }
 
         $this->update($entityProps);
+
+        if ($this->status == EntityStatusStateMachine::APPROVED) {
+            // This state only occurs when an admin is editing an already approved entity. Under these circumstances,
+            // we'd rather see the entity saved with the clean data view than preserve any temporarily set data the
+            // admin might have put in place.
+            $this->cleanConditionalAnswers($form);
+        }
     }
 
     public function calculateCompletion(Form $form): int

--- a/app/Models/Traits/UsesLinkedFields.php
+++ b/app/Models/Traits/UsesLinkedFields.php
@@ -5,6 +5,7 @@ namespace App\Models\Traits;
 use App\Models\Interfaces\HandlesLinkedFieldSync;
 use App\Models\V2\Forms\Form;
 use App\Models\V2\Forms\FormQuestion;
+use App\StateMachines\EntityStatusStateMachine;
 
 trait UsesLinkedFields
 {
@@ -339,13 +340,14 @@ trait UsesLinkedFields
 
         foreach ($childQuestions as $child) {
             if (in_array($child->parent_id, $conditionalsToBeCleaned)) {
-                $fieldConfig = data_get($fieldsConfig, $question->linked_field_key);
+                $fieldConfig = data_get($fieldsConfig, $child->linked_field_key);
                 $property = data_get($fieldConfig, 'property', null);
                 if ($this->isPlainField($child->input_type)) {
-                    $entityProps[$property] = $this->getDefaultValue($child->input_type);
+                    $entityProps[$property] = null;
                 }
             }
         }
+
         $this->update($entityProps);
     }
 
@@ -354,18 +356,5 @@ trait UsesLinkedFields
         $plainFields = ['long-text', 'date', 'number', 'text', 'number-percentage', 'boolean'];
 
         return in_array($input_type, $plainFields);
-    }
-
-    private function getDefaultValue($inputType)
-    {
-        if ($inputType == 'long-text' || $inputType == 'text') {
-            return '';
-        }
-        if ($inputType == 'number' || $inputType == 'number-percentage') {
-            return 0;
-        }
-        if ($inputType == 'boolean') {
-            return false;
-        }
     }
 }

--- a/app/Models/Traits/UsesLinkedFields.php
+++ b/app/Models/Traits/UsesLinkedFields.php
@@ -348,8 +348,8 @@ trait UsesLinkedFields
         foreach ($childQuestions as $child) {
             if (in_array($child->parent_id, $conditionalsToBeCleaned)) {
                 $fieldConfig = data_get($fieldsConfig, $child->linked_field_key);
-                $property = data_get($fieldConfig, 'property', null);
-                if ($this->isPlainField($child->input_type)) {
+                $property = data_get($fieldConfig, 'property');
+                if ($this->isPlainField($child->input_type) && ! empty($property)) {
                     $entityProps[$property] = null;
                 }
             }


### PR DESCRIPTION
https://gfw.atlassian.net/browse/TM-1962

There were a couple of problems here:
* The default value for a form field that has been hidden is not some "empty" value (like `0`, `""` or `false`), it's null. Especially in the case of numerical fields, this has real consequences, as 0 can mean something quite different from null.
* There was a bug in the calculation for which form fields to clear out; it was using `$question` from the block above to pull the linked field key info, instead of `$child`.
* When an admin edits an already approved form, we want to apply the data cleaning right then, as there won't be the normal opportunity to do it later as part of the approval process.

I also updated the one off that runs the cleaning process on all approved reports to give better feedback and progress reporting. It will need to be run again with the next release.