### PR TITLE
[TM-2041] deprecate duplicated function. Keep jobs with demographics.

### DIFF
--- a/app/Http/Resources/V2/Projects/ProjectResource.php
+++ b/app/Http/Resources/V2/Projects/ProjectResource.php
@@ -60,7 +60,7 @@ class ProjectResource extends JsonResource
             // These two are temporary until we have bulk import completed.
             'self_reported_workday_count' => $this->self_reported_workday_count,
             'combined_workday_count' => $this->combined_workday_count,
-            'total_jobs_created' => $this->total_jobs_created,
+            'total_jobs_created' => $this->total_approved_jobs_created,
             'total_approved_jobs_created' => $this->total_approved_jobs_created,
             'approved_volunteers_count' => $this->approved_volunteers_count,
             'total_sites' => $this->total_sites,

--- a/app/Http/Resources/V2/Projects/ProjectWithAdminSchemaResource.php
+++ b/app/Http/Resources/V2/Projects/ProjectWithAdminSchemaResource.php
@@ -45,7 +45,7 @@ class ProjectWithAdminSchemaResource extends JsonResource
             'regenerated_trees_count' => $this->regenerated_trees_count,
             'approved_regenerated_trees_count' => $this->approved_regenerated_trees_count,
             'workday_count' => $this->workday_count,
-            'total_jobs_created' => $this->total_jobs_created,
+            'total_jobs_created' => $this->total_approved_jobs_created,
             'total_sites' => $this->total_sites,
             'total_nurseries' => $this->total_nurseries,
             'total_project_reports' => $this->total_project_reports,

--- a/app/Models/V2/Projects/ProjectReport.php
+++ b/app/Models/V2/Projects/ProjectReport.php
@@ -505,13 +505,6 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
             ->sum('amount');
     }
 
-    public function getTotalJobsCreatedAttribute(): int
-    {
-        $ptTotal = $this->pt_total ?? 0;
-        $ftTotal = $this->ft_total ?? 0;
-
-        return $ftTotal + $ptTotal;
-    }
 
     public function getWorkdaysTotalAttribute(): int
     {

--- a/app/Models/V2/Projects/ProjectReport.php
+++ b/app/Models/V2/Projects/ProjectReport.php
@@ -505,7 +505,6 @@ class ProjectReport extends Model implements MediaModel, AuditableContract, Repo
             ->sum('amount');
     }
 
-
     public function getWorkdaysTotalAttribute(): int
     {
         $projectReportTotal = $this->workdays_paid + $this->workdays_volunteer;


### PR DESCRIPTION
/jobs-created uses demographics

/total-section-headeruses demographics. ( updated in this ticket ) 

getTotalJobsCreatedAttribute is erased from ProjectReport as it was not used anywhere. 
getTotalJobsCreatedAttribute is erased from Project and replaced to use getTotalApprovedJobsCreatedAttribute which get data from demographics. 

getTotalJobsCreatedAttribute and getTotalApprovedJobsCreatedAttribute were identical functions with different approach. 

